### PR TITLE
[plugins.subscribe] ignore marked HOs in global_susbscribes

### DIFF
--- a/hangupsbot/plugins/subscribe.py
+++ b/hangupsbot/plugins/subscribe.py
@@ -87,6 +87,11 @@ def _handle_once(bot, event):
         bot: HangupsBot instance
         event: sync.event.SyncEvent instance
     """
+    # ignore marked HOs
+    if bot.get_config_suboption(event.conv_id, 'ignore_hosubscribe'):
+       return
+
+
     matches = {}
     event_text = event.text.lower()
     previous_targets = event.previous_targets.union(event.targets)

--- a/hangupsbot/plugins/subscribe.py
+++ b/hangupsbot/plugins/subscribe.py
@@ -88,9 +88,9 @@ def _handle_once(bot, event):
         event: sync.event.SyncEvent instance
     """
     # ignore marked HOs
-    if bot.get_config_suboption(event.conv_id, 'ignore_hosubscribe'):
-       return
-
+    if any(bot.get_config_suboption(conv_id, 'ignore_hosubscribe')
+           for conv_id in event.targets):
+        return
 
     matches = {}
     event_text = event.text.lower()


### PR DESCRIPTION
- use conversations suboption “ignore_hosubscribe” to prevent those HOs from triggering global_subscribes