### PR TITLE
[plugins.telesync] fix /restrict_user

### DIFF
--- a/hangupsbot/plugins/telesync/commands_tg.py
+++ b/hangupsbot/plugins/telesync/commands_tg.py
@@ -659,7 +659,10 @@ async def command_restrict_user(tg_bot, msg, *args):
               'can_send_media_messages': True,
               'can_send_other_messages': True,
               'can_add_web_page_previews': True}
-    changes = ({'can_send_messages': False} if restrict == 'messages' else
+    changes = ({'can_send_messages': False,
+                'can_send_media_messages': False,
+                'can_send_other_messages': False,
+                'can_add_web_page_previews': False} if restrict == 'messages' else
                {'can_send_media_messages': False} if restrict == 'media' else
                {'can_send_other_messages': False} if restrict == 'sticker' else
                {'can_add_web_page_previews': False} if restrict == 'websites'


### PR DESCRIPTION
- restricting users from sending messages requires setting all boolean parameters to false (see https://core.telegram.org/bots/api#restrictchatmember for reference)