### PR TITLE
[plugins] add support for protected modules

### DIFF
--- a/hangupsbot/commands/plugincontrol.py
+++ b/hangupsbot/commands/plugincontrol.py
@@ -152,6 +152,8 @@ async def pluginload(bot, event, *args):
 
         except plugins.AlreadyLoaded:
             result = _("already loaded")
+        except plugins.Protected:
+            result = _("protected")
 
         message = _compose_load_message(module_path, result)
 

--- a/tests/test_commands/__init__.py
+++ b/tests/test_commands/__init__.py
@@ -1,0 +1,1 @@
+"""tests for `hangupsbot.commands`"""

--- a/tests/test_commands/test_plugincontrol.py
+++ b/tests/test_commands/test_plugincontrol.py
@@ -1,0 +1,38 @@
+"""test hangupsbot.commands.plugincontrol`"""
+
+import pytest
+
+from hangupsbot import plugins
+
+from tests import run_cmd
+
+
+@pytest.mark.asyncio
+async def test_load_plugin(bot):
+    await plugins.load(bot, 'commands.plugincontrol')
+
+
+@pytest.mark.asyncio
+async def test_pluginload(bot, event):
+    event = event.with_text('/bot pluginload')
+    await run_cmd(bot, event)
+    assert 'module path required' in bot.last_message.text
+
+    event = event.with_text('/bot pluginload plugins')
+    await run_cmd(bot, event)
+    assert 'protected' in bot.last_message.text
+
+    event = event.with_text('/bot pluginload plugins.default')
+    await run_cmd(bot, event)
+    assert '<b>loaded</b>' in bot.last_message.text
+
+    event = event.with_text('/bot pluginload plugins.default')
+    await run_cmd(bot, event)
+    assert 'already loaded' in bot.last_message.text
+
+    # cleanup
+    await plugins.unload(bot, 'plugins.default')
+
+    event = event.with_text('/bot pluginload plugins.<invalid>')
+    await run_cmd(bot, event)
+    assert 'failed' in bot.last_message.text

--- a/tests/test_plugins/test_init.py
+++ b/tests/test_plugins/test_init.py
@@ -1,0 +1,17 @@
+"""test the module `hangupsbot.plugins`"""
+
+import pytest
+
+from hangupsbot import plugins
+
+
+@pytest.mark.asyncio
+async def test_load_protected_module_0(bot):
+    with pytest.raises(plugins.Protected):
+        await plugins.load(bot, 'plugins')
+
+
+@pytest.mark.asyncio
+async def test_load_protected_module_1(bot):
+    with pytest.raises(plugins.Protected):
+        await plugins.load(bot, 'commands')


### PR DESCRIPTION
Modules that are likely to get reloaded by a user my be added to `hangupsbot.plugins.PROTECTED_MODULES`.

https://github.com/das7pad/hangoutsbot/blob/b47ae8d64f968df2380aac958ba1f3c238de25c2/hangupsbot/plugins/__init__.py#L22-L25

This PR resolves #3.