### PR TITLE
upgrade hangups to 0.4.6.1

### DIFF
--- a/hangupsbot/requirements.in
+++ b/hangupsbot/requirements.in
@@ -1,2 +1,2 @@
--e git+https://github.com/das7pad/hangups@v0.4.6.0#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.1#egg=hangups
 appdirs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-dev-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.0#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.1#egg=hangups
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.4.4
 aioresponses==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.0#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.1#egg=hangups
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.4.4
 appdirs==1.4.3


### PR DESCRIPTION
This is a version bump in hangups only.
This monkey patches the installation of hangups via setuptools.

See https://travis-ci.org/das7pad/hangoutsbot/jobs/443424024#L585, `hangups` is pulled from pypi.