### PR TITLE
Feature/add support for latest emoji

### DIFF
--- a/hangupsbot/plugins/_chatbridge/requirements.in
+++ b/hangupsbot/plugins/_chatbridge/requirements.in
@@ -2,5 +2,5 @@ aiohttp>2,<4
 requests
 
 # chatbridge_slack
-emoji==0.4.5
+emoji>=0.4.5,<1
 pyslack

--- a/hangupsbot/plugins/slackrtm/requirements.in
+++ b/hangupsbot/plugins/slackrtm/requirements.in
@@ -2,7 +2,7 @@
 aiohttp>2,<4
 
 # message
-emoji==0.4.5
+emoji>=0.4.5,<1
 
 # parser
 ReParser

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ chardet==3.0.4
 cleverwrap==0.2.3.6
 configargparse==0.13.0
 decorator==4.3.0
-emoji==0.4.5
+emoji==0.5.1
 fudge==1.1.1
 google-api-python-client==1.7.4
 google-auth-httplib2==0.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ chardet==3.0.4
 cleverwrap==0.2.3.6
 configargparse==0.13.0
 decorator==4.3.0
-emoji==0.4.5
+emoji==0.5.1
 fudge==1.1.1
 google-api-python-client==1.7.4
 google-auth-httplib2==0.0.3


### PR DESCRIPTION
Remove the version lock of `emoji==0.4.5` and bump it to `emoji==0.5.1`.

See https://github.com/carpedm20/emoji/commit/e7bff32378721badcdaec4e58d09125e05c5cc12 for the new emojis.