### PR TITLE
[telesync] add a fast path into the periodic membership checker

### DIFF
--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -844,6 +844,11 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                         continue
 
                     for user_id in tuple(data.get('user', ())):
+                        local_path = chat_path + [chat_id, 'user', user_id]
+                        if not self.bot.memory.exists(local_path):
+                            # the user left the chat
+                            continue
+
                         await self.get_tg_user(user_id=user_id,
                                                chat_id=chat_id,
                                                use_cache=False)


### PR DESCRIPTION
We delay the membership check per user by 10-20 seconds.
The stacking delay results in an outdated membership list and a user, that has been marked as left, is not picked up as such.
This patch adds a shortcut route for these users.