### PR TITLE
[plugins.telesync] drop last_seen

### DIFF
--- a/hangupsbot/plugins/telesync/__init__.py
+++ b/hangupsbot/plugins/telesync/__init__.py
@@ -242,8 +242,22 @@ def setup_memory(bot):
 
         telesync_data['version'] = 20180919
 
+    def _cleanup20181112():
+        """drop the last_seen value"""
+        telesync_data = bot.memory['telesync']
+        if telesync_data['version'] >= 20181112:
+            return
+
+        for user in telesync_data['user_data'].values():
+            if 'last_seen' not in user:
+                continue
+            del user['last_seen']
+
+        telesync_data['version'] = 20181112
+
     _migrate_20170609()
     _cleanup20180919()
+    _cleanup20181112()
     bot.memory.save()
 
 

--- a/hangupsbot/plugins/telesync/commands_tg.py
+++ b/hangupsbot/plugins/telesync/commands_tg.py
@@ -854,7 +854,8 @@ async def command_restrict_user(tg_bot, msg, *args):
         lines = [_('/restrict_users failed for:')]
         for user_id, result in failed.items():
             lines.append('- %s:\n  %s' % (
-                (await tg_bot.get_tg_user(user_id)).full_name, repr(result)))
+                (await tg_bot.get_tg_user(user_id, msg.chat_id)).full_name,
+                repr(result)))
 
         tg_bot.send_html(msg.chat_id, '\n'.join(lines))
     else:

--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -790,12 +790,13 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
             last_update_path = ['telesync', 'user_data', user_id, 'last_update']
             if (memory.exists(last_update_path)
                     and memory.get_by_path(last_update_path) == timestamp):
-                return
+                return False
             memory.set_by_path(last_update_path, timestamp)
             logger.info('profile update %s: user %s | chat %s',
                         timestamp, user_id, chat_id)
             await self.get_tg_user(user_id=user_id, chat_id=chat_id,
                                    use_cache=False)
+            return True
 
         try:
             while True:
@@ -805,8 +806,8 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                 logger.info('profile update %s: started', timestamp)
                 for chat_id, data in chat_data.items():
                     for user_id in tuple(data.get('user', ())):
-                        await update_user(chat_id, user_id)
-                        await asyncio.sleep(random.randint(10, 20))
+                        if await update_user(chat_id, user_id):
+                            await asyncio.sleep(random.randint(10, 20))
                 logger.info('profile update %s: finished', timestamp)
 
                 memory.save()

--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -792,18 +792,22 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                     and memory.get_by_path(last_update_path) == timestamp):
                 return
             memory.set_by_path(last_update_path, timestamp)
+            logger.info('profile update %s: user %s | chat %s',
+                        timestamp, user_id, chat_id)
             await self.get_tg_user(user_id=user_id, chat_id=chat_id,
                                    use_cache=False)
 
         try:
             while True:
-                timestamp = time.time()
+                timestamp = int(time.time())
                 chat_data = memory.get_by_path(['telesync', 'chat_data']).copy()
 
+                logger.info('profile update %s: started', timestamp)
                 for chat_id, data in chat_data.items():
                     for user_id in tuple(data.get('user', ())):
                         await update_user(chat_id, user_id)
                         await asyncio.sleep(random.randint(10, 20))
+                logger.info('profile update %s: finished', timestamp)
 
                 await asyncio.sleep(
                     3600 * self.config('profile_update_interval'))

--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -791,6 +791,11 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
             if (memory.exists(last_update_path)
                     and memory.get_by_path(last_update_path) == timestamp):
                 return False
+
+            member_path = ['telesync', 'chat_data', chat_id, 'user', user_id]
+            if not memory.exists(member_path):
+                return False
+
             memory.set_by_path(last_update_path, timestamp)
             logger.info('profile update %s: user %s | chat %s',
                         timestamp, user_id, chat_id)

--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -809,6 +809,7 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                         await asyncio.sleep(random.randint(10, 20))
                 logger.info('profile update %s: finished', timestamp)
 
+                memory.save()
                 await asyncio.sleep(
                     3600 * self.config('profile_update_interval'))
         except asyncio.CancelledError:
@@ -852,6 +853,7 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                                                use_cache=False)
                         await asyncio.sleep(random.randint(10, 20))
 
+                self.bot.memory.save()
                 await asyncio.sleep(
                     3600 * self.config('membership_check_interval'))
         except asyncio.CancelledError:

--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -797,8 +797,10 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                 return False
 
             memory.set_by_path(last_update_path, timestamp)
-            logger.info('profile update %s: user %s | chat %s',
-                        timestamp, user_id, chat_id)
+            logger.debug(
+                'profile update %s: user %s | chat %s',
+                timestamp, user_id, chat_id
+            )
             await self.get_tg_user(user_id=user_id, chat_id=chat_id,
                                    use_cache=False)
             return True
@@ -808,12 +810,18 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                 timestamp = int(time.time())
                 chat_data = memory.get_by_path(['telesync', 'chat_data']).copy()
 
-                logger.info('profile update %s: started', timestamp)
+                logger.debug(
+                    'profile update %s: started',
+                    timestamp
+                )
                 for chat_id, data in chat_data.items():
                     for user_id in tuple(data.get('user', ())):
                         if await update_user(chat_id, user_id):
                             await asyncio.sleep(random.randint(10, 20))
-                logger.info('profile update %s: finished', timestamp)
+                logger.debug(
+                    'profile update %s: finished',
+                    timestamp
+                )
 
                 memory.save()
                 await asyncio.sleep(

--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -315,7 +315,6 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
 
         if self.bot.memory.exists(path_user):
             tg_user = self.bot.memory.get_by_path(path_user)
-            chat_id = chat_id or tg_user['last_seen']
         else:
             tg_user = None
 
@@ -342,7 +341,6 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                                 'memory cleanup error %s: %r',
                                 id(err), err
                             )
-                            tg_user['last_seen'] = None
                             chat_id = None
 
             if tg_user is None:
@@ -650,11 +648,6 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                 type_ = 2
                 if bot.memory.exists(path_chat):
                     bot.memory.pop_by_path(path_chat)
-
-                path_last_seen = ['telesync', 'user_data',
-                                  changed_member.usr_id, 'last_seen']
-                if str(bot.memory.get_by_path(path_last_seen)) == msg.chat_id:
-                    bot.memory.set_by_path(path_last_seen, None)
             else:
                 bot.memory.set_by_path(path_chat, 1)
                 type_ = 1

--- a/hangupsbot/plugins/telesync/user.py
+++ b/hangupsbot/plugins/telesync/user.py
@@ -62,12 +62,6 @@ class User(SyncUser):
         self.bot.memory.ensure_path(path)
         self.bot.memory.get_by_path(path).update(msg[chat_action])
 
-        path += ['last_seen']
-        if not (self.bot.memory.exists(path)
-                and self.bot.memory.get_by_path(path)):
-            # first seen this user or the user has left a chat
-            self.bot.memory.set_by_path(path, msg['chat']['id'])
-
     def get_user_link(self):
         """create a short link with the users username
 


### PR DESCRIPTION
The Telegram Bot API does not provide a method to get a`User` object by its `user_id`. Instead a `getChatMember` method is available, which in turn requires an additional `chat_id`.

We can not provide a matching `chat_id` from every context, e.g. the `/getadmins` command should work in a users private chat. The admins are not member is all these chats and can not be queried with the `chat_id` of the private Chat.
This is where the idea of a `last_seen` `chat_id` came from: we wanted to be able to query every user from every context without iterating over all chats and their user lists.

The implementation is error prone:
Leaving a conversation requires us to discard the `last_seen` value. A failed `getChatMember` request requires us to drop it as well.

Previously the profile updater updated the `last_seen` value first and then updated the users. This has been changed to instant user updates.

Note: `TelegramBot.get_tg_user` still returns a default user for admins that never wrote a message or added/removed a chat member.