### PR TITLE
Hotfix/plugins/telesync/chat member left

### DIFF
--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -63,6 +63,10 @@ if 'default' not in POOLS or POOLS['default'].closed:
 IGNORED_MESSAGE_TYPES = (
     'migrate_from_chat_id',  # duplicate of 'migrate_to_chat_id'
 )
+LEFT_CHAT_MEMBER_STATUS = (
+    'left',
+    'kicked',
+)
 
 telepot.aio.api._timeout = 15  # pylint: disable=protected-access
 PERMANENT_SERVER_ERROR = telepot.exception.TelegramError(
@@ -333,8 +337,8 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                 else:
                     tg_user = response.get('user')
 
-                    if response.get('status') == 'left':
-                        remove_user = 'status: left'
+                    if response.get('status') in LEFT_CHAT_MEMBER_STATUS:
+                        remove_user = 'status: %s' % response.get('status')
 
                 if remove_user:
                     logger.info(

--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -352,7 +352,7 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                              'user', str(user_id)])
                     except KeyError as err:
                         logger.error(
-                            'memory cleanup %s: '
+                            'memory cleanup %s: failed to'
                             'remove user from chat with reason %r: %r',
                             id(tg_user), remove_user, err
                         )


### PR DESCRIPTION
Remove chat members that are flagged as `left` or `kicked`.


---
for ops:
logging format changed for failed memory cleanup:
 - old  `memory cleanup error %s: %r`
 - new `memory cleanup %s: failed to remove user from chat with reason %r: %r`