### PR TITLE
Misc/bring back accurate pylint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ venv-dev: venv-create
 .PHONY: .lint
 .lint:
 	@echo "Lint: started"
-	@$(venv)/bin/pylint -s no -j 4 hangupsbot | sed -r 's/(\*{13})/\n\1/g'
+	@$(venv)/bin/pylint -s no -j 1 hangupsbot | sed -r 's/(\*{13})/\n\1/g'
 	@echo "Lint: no errors found"
 
 # internal: run the test-suite

--- a/hangupsbot/commands/arguments_parser.py
+++ b/hangupsbot/commands/arguments_parser.py
@@ -251,13 +251,3 @@ class ArgumentsParser(BotMixin, TrackingMixin):
             new_args.append(arg)
 
         return new_args
-
-
-def _initialize(bot):
-    """register the arguments parser as shared
-
-    Args:
-        bot (hangupsbot.core.HangupsBot): the running instance
-    """
-    from hangupsbot.commands import command
-    bot.register_shared('arguments_parser', command.arguments_parser)

--- a/hangupsbot/core.py
+++ b/hangupsbot/core.py
@@ -584,6 +584,8 @@ class HangupsBot:
         logger.debug("connected")
 
         self.shared = {}
+        self.register_shared('arguments_parser', command.arguments_parser)
+
         self.tags = tagging.Tags()
         self._handlers = handlers.EventHandler()
 
@@ -608,7 +610,6 @@ class HangupsBot:
         await self._handlers.setup(self._conv_list)
 
         await plugins.load(self, "sync")
-        await plugins.load(self, "commands.arguments_parser")
         await plugins.load(self, "commands.plugincontrol")
         await plugins.load(self, "commands.alias")
         await plugins.load(self, "commands.basic")

--- a/hangupsbot/plugins/api/__init__.py
+++ b/hangupsbot/plugins/api/__init__.py
@@ -128,14 +128,7 @@ class APIRequestHandler(AsyncRequestHandler):
         results = await self.process_request('',  # IGNORED
                                              '',  # IGNORED
                                              payload)
-        if results:
-            content_type = "text/html"
-            results = results.encode("ascii", "xmlcharrefreplace")
-        else:
-            content_type = "text/plain"
-            results = "OK".encode('utf-8')
-
-        return web.Response(body=results, content_type=content_type)
+        self.respond(results)
 
     async def process_request(self, path, _query_string, content):
         # XXX: bit hacky due to different routes...

--- a/hangupsbot/plugins/api/__init__.py
+++ b/hangupsbot/plugins/api/__init__.py
@@ -83,7 +83,7 @@ def _start_api(bot):
             aiohttp_start(
                 bot=bot,
                 name=name,
-                port=port,
+                port=int(port),
                 certfile=certfile,
                 requesthandlerclass=APIRequestHandler,
                 group=__name__)

--- a/hangupsbot/plugins/api/__init__.py
+++ b/hangupsbot/plugins/api/__init__.py
@@ -137,7 +137,7 @@ class APIRequestHandler(AsyncRequestHandler):
 
         return web.Response(body=results, content_type=content_type)
 
-    async def process_request(self, path, query_string, content):
+    async def process_request(self, path, _query_string, content):
         # XXX: bit hacky due to different routes...
         payload = content
         if isinstance(payload, str):

--- a/hangupsbot/plugins/chatlogger.py
+++ b/hangupsbot/plugins/chatlogger.py
@@ -1,5 +1,5 @@
 import logging
-import os
+import pathlib
 
 import hangups
 
@@ -33,14 +33,15 @@ class FileWriter:
         self.paths = list(set(self.paths))
 
         for path in self.paths:
-            # create the directory if it does not exist
-            directory = os.path.dirname(path)
-            if directory and not os.path.isdir(directory):
+            directory = pathlib.Path(path).parent  # type: pathlib.Path
+            if not directory.exists():
                 try:
-                    os.makedirs(directory)
+                    directory.mkdir(exist_ok=True)
                 except OSError as err:
-                    logger.info('create path %s: %r', id(path), path)
-                    logger.error('create path %s: failed: %r', id(path), err)
+                    logger.warning(
+                        'create path %r failed: %r',
+                        path, err
+                    )
                     continue
 
             logger.info("stored in: %s", path)

--- a/hangupsbot/plugins/forwarding.py
+++ b/hangupsbot/plugins/forwarding.py
@@ -41,8 +41,12 @@ def _get_targets(bot, source_id, caller):
     raw_targets = bot.get_config_suboption(source_id, 'forward_to') or []
     targets = set(raw_targets)
     for target in raw_targets:
-        targets.update(bot.sync.get_synced_conversations(conv_id=target,
-                                                         caller=identifier))
+        targets.update(
+            bot.sync.get_synced_conversations(
+                conv_id=target,
+                caller=identifier,
+            )
+        )
     targets.discard(source_id)
     return list(targets)
 

--- a/hangupsbot/plugins/image/image_linker_reddit/__init__.py
+++ b/hangupsbot/plugins/image/image_linker_reddit/__init__.py
@@ -67,11 +67,11 @@ async def _scan_for_triggers(bot, event):
                 elif "imgur.com" in image_link:
                     image_link = image_link.replace(".gifv", ".gif")
                     image_link = image_link.replace(".webm", ".gif")
-                filename = os.path.basename(image_link)
-                async with aiohttp.ClientSession() as session:
-                    async with session.request('get', image_link) as res:
-                        raw = await res.read()
-                image_data = io.BytesIO(raw)
+                image = bot.sync.get_sync_image(
+                    url=image_link,
+                )
+                await image.download()
+                image_data, filename = image.get_data()
                 logger.debug("uploading: %s", filename)
                 image_id = await bot.upload_image(image_data, filename=filename)
             await bot.coro_send_message(event.conv.id_, "", image_id=image_id)

--- a/hangupsbot/plugins/twitter/__init__.py
+++ b/hangupsbot/plugins/twitter/__init__.py
@@ -133,12 +133,11 @@ async def _watch_twitter_link(bot, event):
             images = tweet['extended_entities']['media']
             for image in images:
                 if image['type'] == 'photo':
-                    image_link = image['media_url']
-                    filename = os.path.basename(image_link)
-                    async with aiohttp.ClientSession() as session:
-                        async with session.request('get', image_link) as res:
-                            raw = await res.read()
-                    image_data = io.BytesIO(raw)
+                    image = bot.sync.get_sync_image(
+                        url=image['media_url'],
+                    )
+                    await image.download()
+                    image_data, filename = image.get_data()
                     image_id = await bot.upload_image(image_data,
                                                       filename=filename)
                     await bot.coro_send_message(event.conv.id_, None,

--- a/hangupsbot/sinks/base_bot_request_handler.py
+++ b/hangupsbot/sinks/base_bot_request_handler.py
@@ -38,15 +38,14 @@ class AsyncRequestHandler(BotMixin):
         results = await self.process_request(request.path,
                                              parse_qs(request.query_string),
                                              raw_content.decode("utf-8"))
+        self.respond(results)
 
-        if results:
-            content_type = "text/html"
-            results = results.encode("ascii", "xmlcharrefreplace")
-        else:
-            content_type = "text/plain"
-            results = "OK".encode('utf-8')
-
-        return web.Response(body=results, content_type=content_type)
+    @staticmethod
+    def respond(raw):
+        if not raw:
+            raw = "OK"
+        body = str(raw).encode('utf-8')
+        return web.Response(body=body, content_type="text/plain")
 
     async def process_request(self, path, _query_string, content):
         payload = json.loads(content)

--- a/hangupsbot/sinks/base_bot_request_handler.py
+++ b/hangupsbot/sinks/base_bot_request_handler.py
@@ -87,8 +87,8 @@ class AsyncRequestHandler(BotMixin):
 
         return results
 
-    async def send_data(self, conversation_id, text, image_data=None,
-                        image_filename=None, context=None):
+    async def send_data(self, conversation_id, text,
+                        *, image_data=None, image_filename=None, context=None):
         """sends text and/or image to a conversation
         image_filename is recommended but optional, fallbacks to
         <timestamp>.jpg if undefined

--- a/hangupsbot/sinks/base_bot_request_handler.py
+++ b/hangupsbot/sinks/base_bot_request_handler.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 __all__ = (
     'AsyncRequestHandler',
     'SimpleAsyncRequestHandler',
@@ -49,7 +48,7 @@ class AsyncRequestHandler(BotMixin):
 
         return web.Response(body=results, content_type=content_type)
 
-    async def process_request(self, path, query_string, content):
+    async def process_request(self, path, _query_string, content):
         payload = json.loads(content)
 
         path = path.split("/")
@@ -118,7 +117,7 @@ class AsyncRequestHandler(BotMixin):
 class SimpleAsyncRequestHandler(AsyncRequestHandler):
     logger = logger
 
-    async def process_request(self, path, query_string, content):
+    async def process_request(self, path, _query_string, content):
         conversation_id = path.split("/")[1]
         if not conversation_id:
             self.logger.warning("invalid path %r", path)

--- a/hangupsbot/sinks/base_bot_request_handler.py
+++ b/hangupsbot/sinks/base_bot_request_handler.py
@@ -75,7 +75,9 @@ class AsyncRequestHandler(BotMixin):
                 image_type = imghdr.what('ignore', image_raw)
                 image_filename = str(int(time.time())) + "." + image_type
                 logger.info(
-                    "automatic image filename: {}".format(image_filename))
+                    "automatic image filename: %s",
+                    image_filename
+                )
 
         if not text and not image_data:
             raise ValueError("nothing to send")
@@ -98,7 +100,9 @@ class AsyncRequestHandler(BotMixin):
             if not image_filename:
                 image_filename = str(int(time.time())) + ".jpg"
                 logger.info(
-                    "fallback image filename: {}".format(image_filename))
+                    "fallback image filename: %s",
+                    image_filename
+                )
 
             image_id = await self.bot.upload_image(image_data,
                                                    filename=image_filename)

--- a/hangupsbot/sinks/github/simplepush.py
+++ b/hangupsbot/sinks/github/simplepush.py
@@ -1,27 +1,15 @@
-import json
 import logging
 
-from hangupsbot.sinks.base_bot_request_handler import AsyncRequestHandler
+from hangupsbot.sinks.base_bot_request_handler import SimpleAsyncRequestHandler
 
 
 logger = logging.getLogger(__name__)
 
 
-class WebhookReceiver(AsyncRequestHandler):
+class GitlabWebHookReceiver(SimpleAsyncRequestHandler):
+    logger = logger
 
-    async def process_request(self, path, query_string, content):
-        path = path.split("/")
-        conv_or_user_id = path[1]
-        if conv_or_user_id is None:
-            logger.error("conv id or user id must be provided as part of path")
-            return
-
-        try:
-            payload = json.loads(content)
-        except ValueError as err:
-            logger.error("invalid payload: %r", err)
-            return
-
+    async def process_payload(self, conv_or_user_id, payload):
         if all(key in payload for key in ('repository', 'commits', 'pusher')):
             html = '<b>{}</b> has <a href="{}">pushed</a> {} commit{}\n'.format(
                 payload["pusher"]["name"], payload["repository"]["url"],

--- a/hangupsbot/sinks/gitlab/simplepush.py
+++ b/hangupsbot/sinks/gitlab/simplepush.py
@@ -7,30 +7,18 @@ import logging
 
 import dateutil.parser
 
-from hangupsbot.sinks.base_bot_request_handler import AsyncRequestHandler
+from hangupsbot.sinks.base_bot_request_handler import SimpleAsyncRequestHandler
 
 
 logger = logging.getLogger(__name__)
 
 
-class WebhookReceiver(AsyncRequestHandler):
+class GitlabWebHookReceiver(SimpleAsyncRequestHandler):
     """Receive REST API posts from GitLab"""
+    logger = logger
 
-    async def process_request(self, path, dummy_query_string, content):
+    async def process_payload(self, conv_or_user_id, payload):
         """Process a received POST to a given conversation"""
-        path = path.split("/")
-        conv_or_user_id = path[1]
-        if conv_or_user_id is None:
-            logger.error(
-                "conversation or user id must be provided as part of path")
-            return
-
-        try:
-            payload = json.loads(content)
-        except json.JSONDecodeError as err:
-            logger.error("invalid payload %r", err)
-            return
-
         logger.info("GitLab message: %s", json.dumps(payload))
 
         refs = payload.get("ref", '').split("/")

--- a/hangupsbot/sinks/google/scripts.py
+++ b/hangupsbot/sinks/google/scripts.py
@@ -1,26 +1,15 @@
-import json
 import logging
 
-from hangupsbot.sinks.base_bot_request_handler import AsyncRequestHandler
+from hangupsbot.sinks.base_bot_request_handler import SimpleAsyncRequestHandler
 
 
 logger = logging.getLogger(__name__)
 
 
-class WebhookReceiver(AsyncRequestHandler):
+class GoogleWebHookReceiver(SimpleAsyncRequestHandler):
+    logger = logger
 
-    async def process_request(self, path, query_string, content):
-        path = path.split("/")
-        conv_or_user_id = path[1]
-        if conv_or_user_id is None:
-            logger.error(
-                "conversation or user id must be provided as part of path")
-            return
-
-        payload = content
-        if isinstance(payload, str):
-            payload = json.loads(payload)
-
+    async def process_payload(self, conv_or_user_id, payload):
         if not payload:
             logger.error("payload has nothing")
             return

--- a/pylintrc
+++ b/pylintrc
@@ -159,6 +159,9 @@ ignore-comments=yes
 # Ignore docstrings when computing similarities.
 ignore-docstrings=yes
 
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
 
 [DESIGN]
 


### PR DESCRIPTION
Running `pylint` with the parallel flag results in a degraded lint capability.

Cyclic imports and similar lines were not detected.

Upstream issue: https://github.com/PyCQA/pylint/issues/374