### PR TITLE
Cover edge case for user list updates

### DIFF
--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -563,6 +563,8 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
         except IgnoreMessage:
             logger.debug('message %s: ignore message', id(response))
             return
+        else:
+            msg.update_cache()
 
         if msg.content_type == 'text':
             valid, cmd, params = self._parse_command(msg)

--- a/hangupsbot/plugins/telesync/message.py
+++ b/hangupsbot/plugins/telesync/message.py
@@ -64,6 +64,7 @@ class Message(dict, BotMixin):
         self._set_content()
         self.add_message(self.bot, chat_id, self['message_id'])
 
+    def update_cache(self):
         base_path = ['telesync', 'chat_data', self.chat_id]
 
         if self.user.usr_id != '0':
@@ -73,7 +74,7 @@ class Message(dict, BotMixin):
         else:
             self.bot.memory.ensure_path(base_path)
 
-        self.bot.memory.get_by_path(base_path).update(msg['chat'])
+        self.bot.memory.get_by_path(base_path).update(self['chat'])
 
     @property
     def edited(self):


### PR DESCRIPTION
Do not use reply messages for user list updates.

See these steps that caused a glitch:
1. User A sends a message X into chat 42
2. User A leaves the chat 42
3. User B sends a reply message for X into Chat 42

The bot drops User A from the chats user list in step 2, but adds him back in 3.
This happens as the bot reuses the [`hangupsbot.plugins.telesync.message.Message`](https://github.com/das7pad/hangoutsbot/blob/0d88014b1010265f1144bf47c557262a089fc952/hangupsbot/plugins/telesync/message.py#L42) wrapper for [the reply message as well](https://github.com/das7pad/hangoutsbot/blob/0d88014b1010265f1144bf47c557262a089fc952/hangupsbot/plugins/telesync/message.py#L60). The `Message` constructor would then update the cache [including the membership list](https://github.com/das7pad/hangoutsbot/blob/0d88014b1010265f1144bf47c557262a089fc952/hangupsbot/plugins/telesync/message.py#L72).

This PR addresses this behavior and uses the received message for a cache update only.