### PR TITLE
Keep up with the Google Login

### DIFF
--- a/hangupsbot/core.py
+++ b/hangupsbot/core.py
@@ -221,7 +221,10 @@ class HangupsBot:
                 SystemExit: login failed
             """
             try:
-                return hangups.get_auth_stdin(self._cookies_path)
+                return hangups.get_auth_stdin(
+                    refresh_token_filename=self._cookies_path,
+                    manual_login=True,
+                )
 
             except hangups.GoogleAuthError as err:
                 logger.warning(

--- a/hangupsbot/requirements.in
+++ b/hangupsbot/requirements.in
@@ -1,2 +1,2 @@
--e git+https://github.com/das7pad/hangups@v0.4.6.2#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.3#egg=hangups
 appdirs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-dev-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.2#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.3#egg=hangups
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.4.4
 aioresponses==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.2#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.3#egg=hangups
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.4.4
 appdirs==1.4.3


### PR DESCRIPTION
The Google Login requires javascript to be enabled now.

A work around has been added to hangups, which uses the users browser for the login and the developer tools of the browser to receive the `oauth_code` cookie value.