### PR TITLE
Reuse custom statsd metrics

### DIFF
--- a/hangupsbot/plugins/host/__init__.py
+++ b/hangupsbot/plugins/host/__init__.py
@@ -329,12 +329,17 @@ async def _report_online(bot):
     additional_mentions = bot.config['datadog_notify_in_events']
     if additional_mentions:
         body += '\nNotify: %s' % additional_mentions
-    statsd.event(title_template.format(name=bot_name), body,
-                 alert_type='success')
 
     tags = [
         'user:' + bot_name,
     ]
+
+    statsd.event(
+        title=title_template.format(name=bot_name),
+        text=body,
+        alert_type='success',
+        tags=tags,
+    )
 
     try:
         while bot.config.get_option('report_online'):
@@ -345,8 +350,12 @@ async def _report_online(bot):
             )
             await asyncio.sleep(30)
     except asyncio.CancelledError:
-        statsd.event(_('{name} is going down').format(name=bot_name), body,
-                     alert_type='warning')
+        statsd.event(
+            title=_('{name} is going down').format(name=bot_name),
+            text=body,
+            alert_type='warning',
+            tags=tags,
+        )
 
 
 async def _check_load(bot):

--- a/hangupsbot/plugins/host/__init__.py
+++ b/hangupsbot/plugins/host/__init__.py
@@ -111,13 +111,13 @@ def log_event(bot, event):
 
     tags = []
 
-    if level == 2 or level == 4 or level == 5:
+    if level in (2, 4, 5):
         bot_name = bot.user_self()['full_name'].split()[0]
         bot_name = (''.join(char for char in bot_name if char.isalnum())
                     or 'default')
         tags.append('user:' + bot_name)
 
-    if level == 3 or level == 4 or level == 5:
+    if level in (3, 4, 5):
         platform = event.identifier.rsplit(':', 1)[0]
         tags.append('platform:' + platform)
 

--- a/hangupsbot/plugins/host/__init__.py
+++ b/hangupsbot/plugins/host/__init__.py
@@ -42,10 +42,18 @@ from datetime import (
 )
 
 
+# pylint:disable=invalid-name
 try:
-    from datadog import statsd
+    from datadog import DogStatsd
 except ImportError:
-    statsd = None
+    statsd = DogStatsd = None
+else:
+    statsd = DogStatsd(
+        constant_tags=[
+            'hangupsbot',
+        ]
+    )
+# pylint:enable=invalid-name
 import psutil
 
 from hangupsbot import plugins


### PR DESCRIPTION
This PR merges the custom metrics and adds tags instead of metric postfixes.

In addition all submissions to statsd are tagged with `hangupsbot`.

- events

  new metric: `hangupsbot.messages`

  | old metric | new tags |
  | --- | --- |
  |`hangupsbot.messages.summery` | |
  |`hangupsbot.messages.<bot-name>.summery` | `user:<bot-name>` |
  |`hangupsbot.messages.<platform>.summery` | `platform:<platform>` |
  |`hangupsbot.messages.<bot-name>.<platform>.summery` | `user:<bot-name>`, `platform:<platform>`  |
  |`hangupsbot.messages.<bot-name>.<platform>.<chat_id>` | `user:<bot-name>`, `platform:<platform>`, `<platform>:<chat_id>` |

- online

  old metric: `hangupsbot.online.<bot-name>`

  new metric: `hangupsbot.online` with tag `<bot-name>`