### PR TITLE
Feature/docker/staged build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN sed \
 &&  python3 -c "import imageio; imageio.plugins.ffmpeg.download()" \
         && cd /usr/local/lib/python3*/site-packages/imageio/resources/ \
         && mv /root/.imageio/ffmpeg ./ \
-        && chmod -R 555 ffmpeg/ \
+        && chown -R hangupsbot ffmpeg/ \
 &&  true
 
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,15 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
 &&  true
 
 COPY requirements.txt /app
-RUN pip3 install \
+RUN sed \
+        --expression='s#-e ##' \
+        --in-place=.org \
+        /app/requirements.txt \
+&&  pip3 install \
         --process-dependency-links \
         --no-cache-dir \
-        -r /app/requirements.txt \
+        --requirement /app/requirements.txt \
+&&  mv /app/requirements.txt.org /app/requirements.txt \
 &&  python3 -c "import imageio; imageio.plugins.ffmpeg.download()" \
         && cd /usr/local/lib/python3*/site-packages/imageio/resources/ \
         && mv /root/.imageio/ffmpeg ./ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,15 @@ RUN pip3 install \
         --process-dependency-links \
         --no-cache-dir \
         -r /app/requirements.txt \
+&&  python3 -c "import imageio; imageio.plugins.ffmpeg.download()" \
+        && cd /usr/local/lib/python3*/site-packages/imageio/resources/ \
+        && mv /root/.imageio/ffmpeg ./ \
+        && chmod -R 555 ffmpeg/ \
 &&  true
 
 COPY . /app
 RUN \
     pip3 install /app --process-dependency-links --no-cache-dir && rm -rf /app; \
-    python3 -c "import imageio; imageio.plugins.ffmpeg.download()" && \
-        cd /usr/local/lib/python3*/site-packages/imageio/resources/ && \
-        mv /root/.imageio/ffmpeg ./ && chown -R hangupsbot ffmpeg/; \
     true
 
 USER hangupsbot

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,14 @@ ARG PORTS="9001 9002 9003"
 EXPOSE $PORTS
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+&&  mkdir /app \
+&&  true
+
+COPY requirements.txt /app
+RUN pip3 install \
+        --process-dependency-links \
+        --no-cache-dir \
+        -r /app/requirements.txt \
 &&  true
 
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,15 @@ ARG TZ="Europe/Berlin"
 ARG PORTS="9001 9002 9003"
 EXPOSE $PORTS
 
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+&&  true
+
 COPY . /app
 RUN \
     pip3 install /app --process-dependency-links --no-cache-dir && rm -rf /app; \
     python3 -c "import imageio; imageio.plugins.ffmpeg.download()" && \
         cd /usr/local/lib/python3*/site-packages/imageio/resources/ && \
         mv /root/.imageio/ffmpeg ./ && chown -R hangupsbot ffmpeg/; \
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone; \
     true
 
 USER hangupsbot

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,11 @@ RUN pip3 install \
 &&  true
 
 COPY . /app
-RUN \
-    pip3 install /app --process-dependency-links --no-cache-dir && rm -rf /app; \
-    true
+RUN pip3 install \
+        --process-dependency-links \
+        --no-cache-dir \
+        /app \
+&&  rm -rf /app \
+&&  true
 
 USER hangupsbot


### PR DESCRIPTION
Split the docker `RUN` statements and `COPY` instructions into three parts:
- non `hangupsbot` related
  - timezone setup
  - `/app` directory creation
- requirements installation
  triggered by changes in `requirements.txt`
  - pip requirements installation
  - `ffmpeg` download via `imageio`
- actual `hangupsbot` installation
  triggerd by changes in the `hangupsbot` directory or `setup.py`.

This speeds up the image creation when changing `hangupsbot` code only.