### PR TITLE
[telesync.message] add support for stickers that are not an emoji

### DIFF
--- a/hangupsbot/plugins/telesync/message.py
+++ b/hangupsbot/plugins/telesync/message.py
@@ -221,7 +221,7 @@ class Message(dict, BotMixin):
             self.image_info = sorted_photos[- 1], 'photo'
 
         elif self.content_type == 'sticker':
-            self.text = self["sticker"].get('emoji')
+            self.text = self['sticker'].get('emoji', '')
             self.image_info = self['sticker'], 'sticker'
 
         elif (self.content_type == 'document' and


### PR DESCRIPTION
Cover an Edge case for sticker messages.
Today I received my very first sticker that came in without an emoji attached.

This PR adds an empty string as the fallback text for this type of message.