### PR TITLE
Jenkins/harden build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                     stages {
                         stage('Python:3.5.3 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -64,7 +64,7 @@ pipeline {
                     stages {
                         stage('Python:3.5.4 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -100,7 +100,7 @@ pipeline {
                     stages {
                         stage('Python:3.5.5 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -136,7 +136,7 @@ pipeline {
                     stages {
                         stage('Python:3.5.6 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -172,7 +172,7 @@ pipeline {
                     stages {
                         stage('Python:3.6.0 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -208,7 +208,7 @@ pipeline {
                     stages {
                         stage('Python:3.6.1 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -244,7 +244,7 @@ pipeline {
                     stages {
                         stage('Python:3.6.2 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -280,7 +280,7 @@ pipeline {
                     stages {
                         stage('Python:3.6.3 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -316,7 +316,7 @@ pipeline {
                     stages {
                         stage('Python:3.6.4 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -352,7 +352,7 @@ pipeline {
                     stages {
                         stage('Python:3.6.5 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -388,7 +388,7 @@ pipeline {
                     stages {
                         stage('Python:3.6.6 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -424,7 +424,7 @@ pipeline {
                     stages {
                         stage('Python:3.6.7 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -460,7 +460,7 @@ pipeline {
                     stages {
                         stage('Python:3.7.0 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }
@@ -496,7 +496,7 @@ pipeline {
                     stages {
                         stage('Python:3.7.1 Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
     }
     options {
         timestamps()
+        skipDefaultCheckout(true)
     }
     stages {
         stage('Parallel Stage') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,7 @@ pipeline {
                         stage('Python:3.5.3 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.5.3 Install') {
@@ -65,6 +66,7 @@ pipeline {
                         stage('Python:3.5.4 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.5.4 Install') {
@@ -95,6 +97,7 @@ pipeline {
                         stage('Python:3.5.5 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.5.5 Install') {
@@ -125,6 +128,7 @@ pipeline {
                         stage('Python:3.5.6 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.5.6 Install') {
@@ -155,6 +159,7 @@ pipeline {
                         stage('Python:3.6.0 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.6.0 Install') {
@@ -185,6 +190,7 @@ pipeline {
                         stage('Python:3.6.1 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.6.1 Install') {
@@ -215,6 +221,7 @@ pipeline {
                         stage('Python:3.6.2 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.6.2 Install') {
@@ -245,6 +252,7 @@ pipeline {
                         stage('Python:3.6.3 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.6.3 Install') {
@@ -275,6 +283,7 @@ pipeline {
                         stage('Python:3.6.4 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.6.4 Install') {
@@ -305,6 +314,7 @@ pipeline {
                         stage('Python:3.6.5 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.6.5 Install') {
@@ -335,6 +345,7 @@ pipeline {
                         stage('Python:3.6.6 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.6.6 Install') {
@@ -365,6 +376,7 @@ pipeline {
                         stage('Python:3.6.7 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.6.7 Install') {
@@ -395,6 +407,7 @@ pipeline {
                         stage('Python:3.7.0 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.7.0 Install') {
@@ -425,6 +438,7 @@ pipeline {
                         stage('Python:3.7.1 Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:3.7.1 Install') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,11 @@ pipeline {
                                 sh 'make test'
                             }
                         }
+                        stage('Python:3.5.3 Cleanup') {
+                            steps {
+                                sh 'make clean'
+                            }
+                        }
                     }
                 }
                 stage('Python:3.5.4') {
@@ -77,6 +82,11 @@ pipeline {
                         stage('Python:3.5.4 Test') {
                             steps {
                                 sh 'make test'
+                            }
+                        }
+                        stage('Python:3.5.4 Cleanup') {
+                            steps {
+                                sh 'make clean'
                             }
                         }
                     }
@@ -110,6 +120,11 @@ pipeline {
                                 sh 'make test'
                             }
                         }
+                        stage('Python:3.5.5 Cleanup') {
+                            steps {
+                                sh 'make clean'
+                            }
+                        }
                     }
                 }
                 stage('Python:3.5.6') {
@@ -139,6 +154,11 @@ pipeline {
                         stage('Python:3.5.6 Test') {
                             steps {
                                 sh 'make test'
+                            }
+                        }
+                        stage('Python:3.5.6 Cleanup') {
+                            steps {
+                                sh 'make clean'
                             }
                         }
                     }
@@ -172,6 +192,11 @@ pipeline {
                                 sh 'make test'
                             }
                         }
+                        stage('Python:3.6.0 Cleanup') {
+                            steps {
+                                sh 'make clean'
+                            }
+                        }
                     }
                 }
                 stage('Python:3.6.1') {
@@ -201,6 +226,11 @@ pipeline {
                         stage('Python:3.6.1 Test') {
                             steps {
                                 sh 'make test'
+                            }
+                        }
+                        stage('Python:3.6.1 Cleanup') {
+                            steps {
+                                sh 'make clean'
                             }
                         }
                     }
@@ -234,6 +264,11 @@ pipeline {
                                 sh 'make test'
                             }
                         }
+                        stage('Python:3.6.2 Cleanup') {
+                            steps {
+                                sh 'make clean'
+                            }
+                        }
                     }
                 }
                 stage('Python:3.6.3') {
@@ -263,6 +298,11 @@ pipeline {
                         stage('Python:3.6.3 Test') {
                             steps {
                                 sh 'make test'
+                            }
+                        }
+                        stage('Python:3.6.3 Cleanup') {
+                            steps {
+                                sh 'make clean'
                             }
                         }
                     }
@@ -296,6 +336,11 @@ pipeline {
                                 sh 'make test'
                             }
                         }
+                        stage('Python:3.6.4 Cleanup') {
+                            steps {
+                                sh 'make clean'
+                            }
+                        }
                     }
                 }
                 stage('Python:3.6.5') {
@@ -325,6 +370,11 @@ pipeline {
                         stage('Python:3.6.5 Test') {
                             steps {
                                 sh 'make test'
+                            }
+                        }
+                        stage('Python:3.6.5 Cleanup') {
+                            steps {
+                                sh 'make clean'
                             }
                         }
                     }
@@ -358,6 +408,11 @@ pipeline {
                                 sh 'make test'
                             }
                         }
+                        stage('Python:3.6.6 Cleanup') {
+                            steps {
+                                sh 'make clean'
+                            }
+                        }
                     }
                 }
                 stage('Python:3.6.7') {
@@ -387,6 +442,11 @@ pipeline {
                         stage('Python:3.6.7 Test') {
                             steps {
                                 sh 'make test'
+                            }
+                        }
+                        stage('Python:3.6.7 Cleanup') {
+                            steps {
+                                sh 'make clean'
                             }
                         }
                     }
@@ -420,6 +480,11 @@ pipeline {
                                 sh 'make test'
                             }
                         }
+                        stage('Python:3.7.0 Cleanup') {
+                            steps {
+                                sh 'make clean'
+                            }
+                        }
                     }
                 }
                 stage('Python:3.7.1') {
@@ -449,6 +514,11 @@ pipeline {
                         stage('Python:3.7.1 Test') {
                             steps {
                                 sh 'make test'
+                            }
+                        }
+                        stage('Python:3.7.1 Cleanup') {
+                            steps {
+                                sh 'make clean'
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.5.3 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.5.3 Checkout') {
                             steps {
                                 checkout scm
@@ -49,6 +55,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.5.4 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.5.4 Checkout') {
                             steps {
                                 checkout scm
@@ -73,6 +85,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.5.5 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.5.5 Checkout') {
                             steps {
                                 checkout scm
@@ -97,6 +115,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.5.6 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.5.6 Checkout') {
                             steps {
                                 checkout scm
@@ -121,6 +145,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.6.0 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.6.0 Checkout') {
                             steps {
                                 checkout scm
@@ -145,6 +175,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.6.1 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.6.1 Checkout') {
                             steps {
                                 checkout scm
@@ -169,6 +205,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.6.2 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.6.2 Checkout') {
                             steps {
                                 checkout scm
@@ -193,6 +235,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.6.3 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.6.3 Checkout') {
                             steps {
                                 checkout scm
@@ -217,6 +265,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.6.4 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.6.4 Checkout') {
                             steps {
                                 checkout scm
@@ -241,6 +295,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.6.5 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.6.5 Checkout') {
                             steps {
                                 checkout scm
@@ -265,6 +325,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.6.6 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.6.6 Checkout') {
                             steps {
                                 checkout scm
@@ -289,6 +355,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.6.7 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.6.7 Checkout') {
                             steps {
                                 checkout scm
@@ -313,6 +385,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.7.0 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.7.0 Checkout') {
                             steps {
                                 checkout scm
@@ -337,6 +415,12 @@ pipeline {
                         }
                     }
                     stages {
+                        stage('Python:3.7.1 Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:3.7.1 Checkout') {
                             steps {
                                 checkout scm

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,11 @@ test: venv-dev .test
 # remove the local cache and compiled python files from local directories
 .PHONY: clean
 clean:
-	@echo "Remove the local cache and compiled Python files"
-	@rm -rf .cache `find hangupsbot tests examples -name __pycache__`
+	@echo "Remove the local cache, venv and compiled Python files"
+	@rm -rf \
+		.cache \
+		venv \
+		`find hangupsbot tests examples -name __pycache__`
 
 
 ### internal, house keeping and debugging targets ###

--- a/tools/gen_Jenkinsfile.py
+++ b/tools/gen_Jenkinsfile.py
@@ -83,6 +83,11 @@ STAGE = """
                                 sh 'make test'
                             }
                         }
+                        stage('Python:%(version)s Cleanup') {
+                            steps {
+                                sh 'make clean'
+                            }
+                        }
                     }
                 }
 """

--- a/tools/gen_Jenkinsfile.py
+++ b/tools/gen_Jenkinsfile.py
@@ -70,6 +70,7 @@ STAGE = """
                         stage('Python:%(version)s Checkout') {
                             steps {
                                 checkout scm
+                                sh 'make clean'
                             }
                         }
                         stage('Python:%(version)s Install') {

--- a/tools/gen_Jenkinsfile.py
+++ b/tools/gen_Jenkinsfile.py
@@ -41,6 +41,7 @@ pipeline {
     }
     options {
         timestamps()
+        skipDefaultCheckout(true)
     }
     stages {
         stage('Parallel Stage') {

--- a/tools/gen_Jenkinsfile.py
+++ b/tools/gen_Jenkinsfile.py
@@ -60,6 +60,12 @@ STAGE = """
                         }
                     }
                     stages {
+                        stage('Python:%(version)s Info') {
+                            steps {
+                                sh 'curl httpbin.org/ip'
+                                sh 'pwd'
+                            }
+                        }
                         stage('Python:%(version)s Checkout') {
                             steps {
                                 checkout scm

--- a/tools/gen_Jenkinsfile.py
+++ b/tools/gen_Jenkinsfile.py
@@ -63,7 +63,7 @@ STAGE = """
                     stages {
                         stage('Python:%(version)s Info') {
                             steps {
-                                sh 'curl httpbin.org/ip'
+                                sh 'curl -sS httpbin.org/ip'
                                 sh 'pwd'
                             }
                         }


### PR DESCRIPTION
The cleanup performed by jekins via `Clean Build`, `Clean before checkout`, `Clean after checkout` is not sufficient.

The `venv` directory remains on disk as it contains the repositories of `hangups` and `telepot` in a sub-directory `src`. The cleanup is performed via git, which does not remove other repositories by default.

Additional steps were added:
- add the `venv` directory into the `clean` target of the `Makefile` 
- run explicit cleanup after the checkout
  - run `make clean`
- add a cleanup stage after the test stage
  - run `make clean`
- add an info stage:
  -  get the worker IP
  - log the working dir