### PR TITLE
[telesync.core] membership checker: fix a typo in the config path usage

### DIFF
--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -869,8 +869,8 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
                 for chat_id, data in chat_data.copy().items():
                     config_path = ['conversations', 'telesync:%s' % chat_id,
                                    'enable_membership_check']
-                    if self.bot.memory.exists(config_path):
-                        enabled = self.bot.memory.get_by_path(config_path)
+                    if self.bot.config.exists(config_path):
+                        enabled = self.bot.config.get_by_path(config_path)
                     else:
                         enabled = self.config('enable_membership_check')
 


### PR DESCRIPTION
To resolve a `config_path` one has to query `self.bot.`**config** instead of `self.bot.`**memory**.