### PR TITLE
bump requests to 2.21.0 for idna v2.8 support

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -61,7 +61,7 @@ raven==6.9.0
 readlike==0.1.3
 reparser==1.4.3
 requests-oauthlib==1.0.0
-requests==2.20.1
+requests==2.21.0
 rsa==4.0
 selenium==3.141.0
 simplejson==3.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ raven==6.9.0
 readlike==0.1.3
 reparser==1.4.3
 requests-oauthlib==1.0.0
-requests==2.20.1
+requests==2.21.0
 rsa==4.0
 selenium==3.141.0
 simplejson==3.16.0


### PR DESCRIPTION
`requests==2.20.1` is not compatible with `idna==2.8`.

We must run `pip-compile` in the pyup-bot PR-branch to uncover these incompatibilities.