### PR TITLE
upgrade hangups to 0.4.6.6

### DIFF
--- a/hangupsbot/requirements.in
+++ b/hangupsbot/requirements.in
@@ -1,2 +1,2 @@
--e git+https://github.com/das7pad/hangups@v0.4.6.3#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.4#egg=hangups
 appdirs

--- a/hangupsbot/requirements.in
+++ b/hangupsbot/requirements.in
@@ -1,2 +1,2 @@
--e git+https://github.com/das7pad/hangups@v0.4.6.4#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.5#egg=hangups
 appdirs

--- a/hangupsbot/requirements.in
+++ b/hangupsbot/requirements.in
@@ -1,2 +1,2 @@
--e git+https://github.com/das7pad/hangups@v0.4.6.5#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.6#egg=hangups
 appdirs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-dev-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.4#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.5#egg=hangups
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.4.4
 aioresponses==0.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-dev-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.3#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.4#egg=hangups
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.4.4
 aioresponses==0.5.0
@@ -19,7 +19,6 @@ cachetools==3.0.0
 certifi==2018.11.29
 chardet==3.0.4
 cleverwrap==0.2.3.6
-configargparse==0.13.0
 decorator==4.3.0
 emoji==0.5.1
 fudge==1.1.1
@@ -36,7 +35,6 @@ jaraco.itertools==3.0.0
 lazy-object-proxy==1.3.1
 lxml==4.2.5
 mccabe==0.6.1
-mechanicalsoup==0.11.0
 more-itertools==4.3.0
 moviepy==0.2.3.5
 multidict==4.5.2
@@ -58,7 +56,6 @@ python-dateutil==2.7.5
 python-magic==0.4.15
 raven-aiohttp==0.7.0
 raven==6.9.0
-readlike==0.1.3
 reparser==1.4.3
 requests-oauthlib==1.0.0
 requests==2.21.0
@@ -73,7 +70,6 @@ twitterapi==2.5.4
 typed-ast==1.1.0
 uritemplate==3.0.0
 urllib3==1.24.1
-urwid==2.0.1
 websocket-client==0.54.0
 wikipedia==1.4.0
 wolframalpha==3.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-dev-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.5#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.6#egg=hangups
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.4.4
 aioresponses==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.3#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.4#egg=hangups
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.4.4
 appdirs==1.4.3
@@ -16,7 +16,6 @@ cachetools==3.0.0
 certifi==2018.11.29
 chardet==3.0.4
 cleverwrap==0.2.3.6
-configargparse==0.13.0
 decorator==4.3.0
 emoji==0.5.1
 fudge==1.1.1
@@ -30,7 +29,6 @@ imageio==2.4.1
 inflect==2.1.0
 jaraco.itertools==3.0.0
 lxml==4.2.5
-mechanicalsoup==0.11.0
 more-itertools==4.3.0
 moviepy==0.2.3.5
 multidict==4.5.2
@@ -47,7 +45,6 @@ python-dateutil==2.7.5
 python-magic==0.4.15
 raven-aiohttp==0.7.0
 raven==6.9.0
-readlike==0.1.3
 reparser==1.4.3
 requests-oauthlib==1.0.0
 requests==2.21.0
@@ -61,7 +58,6 @@ tqdm==4.28.1
 twitterapi==2.5.4
 uritemplate==3.0.0
 urllib3==1.24.1
-urwid==2.0.1
 websocket-client==0.54.0
 wikipedia==1.4.0
 wolframalpha==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.4#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.5#egg=hangups
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.4.4
 appdirs==1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.5#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.6#egg=hangups
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.4.4
 appdirs==1.4.3


### PR DESCRIPTION
- `0.4.6.4`:
  https://github.com/das7pad/hangups/releases/tag/v0.4.6.4
  Summery:
  - split core and ui dependencies
  - first login: use the manual login by default, automated login via email, password, 2FA is blocked by Google.
- `0.4.6.5`:
  https://github.com/das7pad/hangups/releases/tag/v0.4.6.5
  Summery:
  - auto link regex update