### PR TITLE
[telesync] message coverage

### DIFF
--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -572,7 +572,7 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
             self._on_supergroup_upgrade(response)
             return
 
-        if (telepot.flavor(response) != 'chat'
+        if ('message_id' not in response
                 or any(key in response for key in IGNORED_MESSAGE_TYPES)):
             return
 

--- a/hangupsbot/plugins/telesync/core.py
+++ b/hangupsbot/plugins/telesync/core.py
@@ -43,7 +43,10 @@ from .commands_tg import (
     command_whois,
     restrict_users,
 )
-from .exceptions import IgnoreMessage
+from .exceptions import (
+    IgnoreMessage,
+    NotSupportedMessageType,
+)
 from .message import Message
 from .parsers import TelegramMessageSegment
 from .user import User
@@ -577,6 +580,12 @@ class TelegramBot(telepot.aio.Bot, BotMixin):
             msg = Message(response)
         except IgnoreMessage:
             logger.debug('message %s: ignore message', id(response))
+            return
+        except NotSupportedMessageType:
+            logger.debug(
+                'message %s: message type is not supported',
+                id(response),
+            )
             return
         else:
             msg.update_cache()

--- a/hangupsbot/plugins/telesync/exceptions.py
+++ b/hangupsbot/plugins/telesync/exceptions.py
@@ -3,3 +3,7 @@
 
 class IgnoreMessage(Exception):
     """message content should not be synced"""
+
+
+class NotSupportedMessageType(Exception):
+    """Message type is not supported"""

--- a/hangupsbot/plugins/telesync/message.py
+++ b/hangupsbot/plugins/telesync/message.py
@@ -66,8 +66,18 @@ class Message(dict, BotMixin):
             raise NotSupportedMessageType
 
         self.chat_id = str(chat_id)
-        self.reply = (Message(msg['reply_to_message'])
-                      if 'reply_to_message' in msg else None)
+
+        reply = None
+        if 'reply_to_message' in msg:
+            try:
+                reply = Message(msg['reply_to_message'])
+            except NotSupportedMessageType:
+                logger.debug(
+                    'message %s: reply message type is not supported',
+                    id(msg),
+                )
+        self.reply = reply
+
         self.user = User(self.tg_bot, msg)
         self.image_info = None
         self._set_content()

--- a/hangupsbot/plugins/telesync/message.py
+++ b/hangupsbot/plugins/telesync/message.py
@@ -9,7 +9,10 @@ from hangupsbot.base_models import BotMixin
 from hangupsbot.sync.event import SyncReply
 from hangupsbot.sync.user import SyncUser
 from hangupsbot.utils.cache import Cache
-from .exceptions import IgnoreMessage
+from .exceptions import (
+    IgnoreMessage,
+    NotSupportedMessageType,
+)
 from .user import User
 
 
@@ -49,13 +52,19 @@ class Message(dict, BotMixin):
 
     Raises:
         IgnoreMessage: the message should not be synced
+        NotSupportedMessageType: the message type is not supported
     """
     tg_bot = None
     _last_messages = {}
 
     def __init__(self, msg):
         super().__init__(msg)
-        self.content_type, self.chat_type, chat_id = telepot.glance(msg)
+
+        try:
+            self.content_type, self.chat_type, chat_id = telepot.glance(msg)
+        except KeyError:
+            raise NotSupportedMessageType
+
         self.chat_id = str(chat_id)
         self.reply = (Message(msg['reply_to_message'])
                       if 'reply_to_message' in msg else None)


### PR DESCRIPTION
As per the [Telegram Bot-API docs](https://core.telegram.org/bots/api#message) `Message` objects may omit all fields except for `message_id`, `date` and `chat`.

Previously this was not an issue as all messages also provided a `text`, `sticker`, `photo`, `video`, `document`, `left_chat_member`...

This has changed with extended features in the various Telegram clients.

A bot of mine received two `Message`s that included rather empty replys.
- one was for a reply to a membership change
- another one for a poll

These messages included just the base `message_id`, `date` and `chat` keys. By comparing the timestamps I was able to determine the initial messages.

---

This PR hardens the handling of incoming messages.