### PR TITLE
[make] update the targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,22 +12,22 @@ venv: install-requirements
 .PHONY: install-requirements
 install-requirements: venv-create
 	@echo "Installing requirements"
-	@$(pip) install --requirement requirements.txt
+	$(pip) install --requirement requirements.txt
 	@echo "Done"
 
 # install the hangupsbot package into a venv
 .PHONY: install
 install: venv-create
 	@echo "Install: started"
-	@rm -rf `find hangupsbot -name __pycache__`
-	@$(pip) install . --process-dependency-links --upgrade
+	rm -rf `find hangupsbot -name __pycache__`
+	$(pip) install . --process-dependency-links --upgrade
 	@echo "Install: finished"
 
 # update or reinstall all packages
 .PHONY: update-requirements
 update-requirements: venv-create
 	@echo "Updating requirements"
-	@$(pip) install --requirement requirements.txt --upgrade
+	$(pip) install --requirement requirements.txt --upgrade
 	@echo "Done"
 
 # check the venv and run pylint
@@ -46,7 +46,7 @@ test: venv-dev .test
 .PHONY: clean
 clean:
 	@echo "Remove the local cache, venv and compiled Python files"
-	@rm -rf \
+	rm -rf \
 		.cache \
 		venv \
 		`find hangupsbot tests examples -name __pycache__`
@@ -56,27 +56,27 @@ clean:
 
 # house keeping: update the Jenkinsfile
 Jenkinsfile: tools/gen_Jenkinsfile.py
-	@$(python) tools/gen_Jenkinsfile.py
+	$(python) tools/gen_Jenkinsfile.py
 
 # house keeping: update the localization
 .PHONY: localization
 localization:
-	@make -s --directory hangupsbot/locale
+	make --directory hangupsbot/locale
 
 # internal: ensure an existing venv
 .PHONY: venv-create
 venv-create: $(pip)
 $(pip):
 	@echo "Creating venv"
-	@${python} -m venv $(venv)
+	${python} -m venv $(venv)
 
 # internal: check for `pip-compile` and ensure an existing cache directory
 .PHONY: .gen-requirements
 .gen-requirements: $(venv)/pip-tools
 $(venv)/pip-tools: $(pip)
 	@echo "Installing pip-tools"
-	@$(pip) install pip-tools
-	@touch $(venv)/pip-tools
+	$(pip) install pip-tools
+	touch $(venv)/pip-tools
 	@echo "Done"
 
 # house keeping: update `requirements.txt`:
@@ -84,7 +84,7 @@ $(venv)/pip-tools: $(pip)
 .PHONY: gen-requirements
 gen-requirements: .gen-requirements
 	@echo "Gathering requirements"
-	@CUSTOM_COMPILE_COMMAND="make gen-requirements" \
+	CUSTOM_COMPILE_COMMAND="make gen-requirements" \
 	    $(venv)/bin/pip-compile \
 	        --upgrade \
 	        --no-annotate \
@@ -100,7 +100,7 @@ gen-requirements: .gen-requirements
 .PHONY: gen-dev-requirements
 gen-dev-requirements: .gen-requirements
 	@echo "Gathering development requirements"
-	@CUSTOM_COMPILE_COMMAND="make gen-dev-requirements" \
+	CUSTOM_COMPILE_COMMAND="make gen-dev-requirements" \
 	    $(venv)/bin/pip-compile \
 	        --upgrade \
 	        --no-annotate \
@@ -116,22 +116,22 @@ gen-dev-requirements: .gen-requirements
 venv-dev: $(venv)/dev
 $(venv)/dev: $(pip) requirements-dev.txt
 	@echo "Installing Dev requirements"
-	@$(pip) install --requirement requirements-dev.txt
-	@touch $(venv)/dev
+	$(pip) install --requirement requirements-dev.txt
+	touch $(venv)/dev
 	@echo "Done"
 
 # internal: run pylint, prepend extra blank lines for each module
 .PHONY: .lint
 .lint:
 	@echo "Lint: started"
-	@$(venv)/bin/pylint -s no -j 1 hangupsbot
+	$(venv)/bin/pylint -s no -j 1 hangupsbot
 	@echo "Lint: no errors found"
 
 # internal: run the test-suite
 .PHONY: .test-only
 .test-only:
 	@echo "Tests: started"
-	@$(venv)/bin/py.test -v tests
+	$(venv)/bin/py.test -v tests
 	@echo "Tests: all completed"
 
 # internal: run pylint and the test-suite
@@ -142,5 +142,5 @@ $(venv)/dev: $(pip) requirements-dev.txt
 .PHONY: test-only-verbose
 test-only-verbose:
 	@echo "Tests: started in verbose mode"
-	@$(venv)/bin/py.test -vvv tests
+	$(venv)/bin/py.test -vvv tests
 	@echo "Tests: all completed"

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ $(venv)/dev: $(pip) requirements-dev.txt
 .PHONY: .lint
 .lint:
 	@echo "Lint: started"
-	@$(venv)/bin/pylint -s no -j 1 hangupsbot | sed -r 's/(\*{13})/\n\1/g'
+	@$(venv)/bin/pylint -s no -j 1 hangupsbot
 	@echo "Lint: no errors found"
 
 # internal: run the test-suite

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,11 @@ gen-dev-requirements: .gen-requirements
 
 # internal: ensure a venv with dev requirements
 .PHONY: venv-dev
-venv-dev: venv-create
+venv-dev: $(venv)/dev
+$(venv)/dev: $(pip) requirements-dev.txt
 	@echo "Installing Dev requirements"
 	@$(pip) install --requirement requirements-dev.txt
+	@touch $(venv)/dev
 	@echo "Done"
 
 # internal: run pylint, prepend extra blank lines for each module

--- a/Makefile
+++ b/Makefile
@@ -11,24 +11,18 @@ venv: install-requirements
 # create a venv for running the hangupsbot
 .PHONY: install-requirements
 install-requirements: venv-create
-	@echo "Installing requirements"
 	$(pip) install --requirement requirements.txt
-	@echo "Done"
 
 # install the hangupsbot package into a venv
 .PHONY: install
 install: venv-create
-	@echo "Install: started"
 	rm -rf `find hangupsbot -name __pycache__`
 	$(pip) install . --process-dependency-links --upgrade
-	@echo "Install: finished"
 
 # update or reinstall all packages
 .PHONY: update-requirements
 update-requirements: venv-create
-	@echo "Updating requirements"
 	$(pip) install --requirement requirements.txt --upgrade
-	@echo "Done"
 
 # check the venv and run pylint
 .PHONY: lint
@@ -45,7 +39,6 @@ test: venv-dev .test
 # remove the local cache and compiled python files from local directories
 .PHONY: clean
 clean:
-	@echo "Remove the local cache, venv and compiled Python files"
 	rm -rf \
 		.cache \
 		venv \
@@ -67,23 +60,19 @@ localization:
 .PHONY: venv-create
 venv-create: $(pip)
 $(pip):
-	@echo "Creating venv"
 	${python} -m venv $(venv)
 
 # internal: check for `pip-compile` and ensure an existing cache directory
 .PHONY: .gen-requirements
 .gen-requirements: $(venv)/pip-tools
 $(venv)/pip-tools: $(pip)
-	@echo "Installing pip-tools"
 	$(pip) install pip-tools
 	touch $(venv)/pip-tools
-	@echo "Done"
 
 # house keeping: update `requirements.txt`:
 # pip-compile prints everything to stdout as well, direct it to /dev/null
 .PHONY: gen-requirements
 gen-requirements: .gen-requirements
-	@echo "Gathering requirements"
 	CUSTOM_COMPILE_COMMAND="make gen-requirements" \
 	    $(venv)/bin/pip-compile \
 	        --upgrade \
@@ -93,13 +82,11 @@ gen-requirements: .gen-requirements
 	        --output-file requirements.txt \
 	        `find hangupsbot -name requirements.in` \
         > /dev/null
-	@echo "Done"
 
 # house keeping: update `requirements-dev.txt`:
 # gather requirements from ./hangupsbot and ./tests
 .PHONY: gen-dev-requirements
 gen-dev-requirements: .gen-requirements
-	@echo "Gathering development requirements"
 	CUSTOM_COMPILE_COMMAND="make gen-dev-requirements" \
 	    $(venv)/bin/pip-compile \
 	        --upgrade \
@@ -109,30 +96,23 @@ gen-dev-requirements: .gen-requirements
 	        --output-file requirements-dev.txt \
 	        `find hangupsbot tests -name requirements.in` \
         > /dev/null
-	@echo "Done"
 
 # internal: ensure a venv with dev requirements
 .PHONY: venv-dev
 venv-dev: $(venv)/dev
 $(venv)/dev: $(pip) requirements-dev.txt
-	@echo "Installing Dev requirements"
 	$(pip) install --requirement requirements-dev.txt
 	touch $(venv)/dev
-	@echo "Done"
 
 # internal: run pylint, prepend extra blank lines for each module
 .PHONY: .lint
 .lint:
-	@echo "Lint: started"
 	$(venv)/bin/pylint -s no -j 1 hangupsbot
-	@echo "Lint: no errors found"
 
 # internal: run the test-suite
 .PHONY: .test-only
 .test-only:
-	@echo "Tests: started"
 	$(venv)/bin/py.test -v tests
-	@echo "Tests: all completed"
 
 # internal: run pylint and the test-suite
 .PHONY: .test
@@ -141,6 +121,4 @@ $(venv)/dev: $(pip) requirements-dev.txt
 # debugging: run the test suite verbose
 .PHONY: test-only-verbose
 test-only-verbose:
-	@echo "Tests: started in verbose mode"
 	$(venv)/bin/py.test -vvv tests
-	@echo "Tests: all completed"

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,7 @@ clean:
 ### internal, house keeping and debugging targets ###
 
 # house keeping: update the Jenkinsfile
-.PHONY: Jenkinsfile
-Jenkinsfile:
+Jenkinsfile: tools/gen_Jenkinsfile.py
 	@$(python) tools/gen_Jenkinsfile.py
 
 # house keeping: update the localization

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,10 @@ localization:
 
 # internal: ensure an existing venv
 .PHONY: venv-create
-venv-create:
-	@if [ ! -d $(venv) ]; then \
-		echo "Creating venv" && ${python} -m venv $(venv); fi
+venv-create: $(pip)
+$(pip):
+	@echo "Creating venv"
+	@${python} -m venv $(venv)
 
 # internal: check for `pip-compile` and ensure an existing cache directory
 .PHONY: .gen-requirements

--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,12 @@ $(pip):
 
 # internal: check for `pip-compile` and ensure an existing cache directory
 .PHONY: .gen-requirements
-.gen-requirements: venv-create
-	@if [ ! -d $(venv)/lib/*/site-packages/piptools ]; then \
-		echo "Installing pip-tools" && $(pip) install -q pip-tools \
-		echo "Done"; fi
-	@if [ ! -d .cache ]; then mkdir .cache; fi
+.gen-requirements: $(venv)/pip-tools
+$(venv)/pip-tools: $(pip)
+	@echo "Installing pip-tools"
+	@$(pip) install pip-tools
+	@touch $(venv)/pip-tools
+	@echo "Done"
 
 # house keeping: update `requirements.txt`:
 # pip-compile prints everything to stdout as well, direct it to /dev/null


### PR DESCRIPTION
The lint and test/test-only targets ran the dev-requirements installation on each invocation. This is actually only needed when running it the first time or when requirements were bumped.

`make` uses stat calls on dependencies and build artifacts to determine whether a build is needed. Did the source change since we build it the last time? -> build again.

Build artifacts are basically empty files in this case.

There was a glitch with `git clean` and the venv-create make target: git clean does not remove child repositories, git-requirements are checked out in the `venv` directory, as such they remained. The `venv` directory would remain on disk with just the `venv/src/` child.

I have chosen these _build artifacts_:

| make target | artifact | source | comment |
| --- | --- | :---: | --- |
| `venv-create` | `$VENV/bin/pip` | - | create venv |
| `venv-dev` | `$VENV/dev` | `requirements-dev.txt` | install dev-requirements |
| `.gen-requirements` | `$VENV/pip-tools` | - | install `pip-tools` which contain `pip-compile` |
| `Jenkinsfile` | `Jenkinsfile` | `tools/gen_Jenkinsfile.py` | update the `Jenkins` pipeline |


In addition I remove inconsistent status messages that were printed on the screen and brought back the actual commands instead.