### PR TITLE
[jenkins] refactor the stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,9 +43,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.5.3 Test') {
+                        stage('Python:3.5.3 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.5.3 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.5.3 Cleanup') {
@@ -79,9 +84,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.5.4 Test') {
+                        stage('Python:3.5.4 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.5.4 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.5.4 Cleanup') {
@@ -115,9 +125,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.5.5 Test') {
+                        stage('Python:3.5.5 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.5.5 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.5.5 Cleanup') {
@@ -151,9 +166,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.5.6 Test') {
+                        stage('Python:3.5.6 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.5.6 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.5.6 Cleanup') {
@@ -187,9 +207,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.6.0 Test') {
+                        stage('Python:3.6.0 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.6.0 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.6.0 Cleanup') {
@@ -223,9 +248,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.6.1 Test') {
+                        stage('Python:3.6.1 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.6.1 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.6.1 Cleanup') {
@@ -259,9 +289,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.6.2 Test') {
+                        stage('Python:3.6.2 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.6.2 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.6.2 Cleanup') {
@@ -295,9 +330,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.6.3 Test') {
+                        stage('Python:3.6.3 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.6.3 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.6.3 Cleanup') {
@@ -331,9 +371,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.6.4 Test') {
+                        stage('Python:3.6.4 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.6.4 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.6.4 Cleanup') {
@@ -367,9 +412,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.6.5 Test') {
+                        stage('Python:3.6.5 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.6.5 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.6.5 Cleanup') {
@@ -403,9 +453,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.6.6 Test') {
+                        stage('Python:3.6.6 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.6.6 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.6.6 Cleanup') {
@@ -439,9 +494,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.6.7 Test') {
+                        stage('Python:3.6.7 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.6.7 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.6.7 Cleanup') {
@@ -475,9 +535,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.7.0 Test') {
+                        stage('Python:3.7.0 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.7.0 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.7.0 Cleanup') {
@@ -511,9 +576,14 @@ pipeline {
                                 sh 'make install'
                             }
                         }
-                        stage('Python:3.7.1 Test') {
+                        stage('Python:3.7.1 Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:3.7.1 Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:3.7.1 Cleanup') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,11 +38,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.5.3 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.5.3 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -56,6 +51,11 @@ pipeline {
                         stage('Python:3.5.3 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.5.3 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.5.3 Cleanup') {
@@ -84,11 +84,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.5.4 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.5.4 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -102,6 +97,11 @@ pipeline {
                         stage('Python:3.5.4 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.5.4 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.5.4 Cleanup') {
@@ -130,11 +130,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.5.5 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.5.5 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -148,6 +143,11 @@ pipeline {
                         stage('Python:3.5.5 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.5.5 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.5.5 Cleanup') {
@@ -176,11 +176,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.5.6 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.5.6 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -194,6 +189,11 @@ pipeline {
                         stage('Python:3.5.6 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.5.6 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.5.6 Cleanup') {
@@ -222,11 +222,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.6.0 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.6.0 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -240,6 +235,11 @@ pipeline {
                         stage('Python:3.6.0 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.6.0 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.6.0 Cleanup') {
@@ -268,11 +268,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.6.1 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.6.1 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -286,6 +281,11 @@ pipeline {
                         stage('Python:3.6.1 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.6.1 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.6.1 Cleanup') {
@@ -314,11 +314,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.6.2 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.6.2 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -332,6 +327,11 @@ pipeline {
                         stage('Python:3.6.2 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.6.2 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.6.2 Cleanup') {
@@ -360,11 +360,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.6.3 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.6.3 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -378,6 +373,11 @@ pipeline {
                         stage('Python:3.6.3 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.6.3 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.6.3 Cleanup') {
@@ -406,11 +406,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.6.4 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.6.4 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -424,6 +419,11 @@ pipeline {
                         stage('Python:3.6.4 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.6.4 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.6.4 Cleanup') {
@@ -452,11 +452,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.6.5 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.6.5 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -470,6 +465,11 @@ pipeline {
                         stage('Python:3.6.5 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.6.5 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.6.5 Cleanup') {
@@ -498,11 +498,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.6.6 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.6.6 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -516,6 +511,11 @@ pipeline {
                         stage('Python:3.6.6 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.6.6 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.6.6 Cleanup') {
@@ -544,11 +544,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.6.7 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.6.7 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -562,6 +557,11 @@ pipeline {
                         stage('Python:3.6.7 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.6.7 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.6.7 Cleanup') {
@@ -590,11 +590,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.7.0 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.7.0 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -608,6 +603,11 @@ pipeline {
                         stage('Python:3.7.0 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.7.0 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.7.0 Cleanup') {
@@ -636,11 +636,6 @@ pipeline {
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:3.7.1 Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:3.7.1 Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -654,6 +649,11 @@ pipeline {
                         stage('Python:3.7.1 Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:3.7.1 Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:3.7.1 Cleanup') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,11 @@ pipeline {
                                 sh 'make install'
                             }
                         }
+                        stage('Python:3.5.3 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
+                            }
+                        }
                         stage('Python:3.5.3 Lint') {
                             steps {
                                 sh 'make lint'
@@ -82,6 +87,11 @@ pipeline {
                         stage('Python:3.5.4 Install') {
                             steps {
                                 sh 'make install'
+                            }
+                        }
+                        stage('Python:3.5.4 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
                             }
                         }
                         stage('Python:3.5.4 Lint') {
@@ -125,6 +135,11 @@ pipeline {
                                 sh 'make install'
                             }
                         }
+                        stage('Python:3.5.5 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
+                            }
+                        }
                         stage('Python:3.5.5 Lint') {
                             steps {
                                 sh 'make lint'
@@ -164,6 +179,11 @@ pipeline {
                         stage('Python:3.5.6 Install') {
                             steps {
                                 sh 'make install'
+                            }
+                        }
+                        stage('Python:3.5.6 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
                             }
                         }
                         stage('Python:3.5.6 Lint') {
@@ -207,6 +227,11 @@ pipeline {
                                 sh 'make install'
                             }
                         }
+                        stage('Python:3.6.0 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
+                            }
+                        }
                         stage('Python:3.6.0 Lint') {
                             steps {
                                 sh 'make lint'
@@ -246,6 +271,11 @@ pipeline {
                         stage('Python:3.6.1 Install') {
                             steps {
                                 sh 'make install'
+                            }
+                        }
+                        stage('Python:3.6.1 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
                             }
                         }
                         stage('Python:3.6.1 Lint') {
@@ -289,6 +319,11 @@ pipeline {
                                 sh 'make install'
                             }
                         }
+                        stage('Python:3.6.2 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
+                            }
+                        }
                         stage('Python:3.6.2 Lint') {
                             steps {
                                 sh 'make lint'
@@ -328,6 +363,11 @@ pipeline {
                         stage('Python:3.6.3 Install') {
                             steps {
                                 sh 'make install'
+                            }
+                        }
+                        stage('Python:3.6.3 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
                             }
                         }
                         stage('Python:3.6.3 Lint') {
@@ -371,6 +411,11 @@ pipeline {
                                 sh 'make install'
                             }
                         }
+                        stage('Python:3.6.4 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
+                            }
+                        }
                         stage('Python:3.6.4 Lint') {
                             steps {
                                 sh 'make lint'
@@ -410,6 +455,11 @@ pipeline {
                         stage('Python:3.6.5 Install') {
                             steps {
                                 sh 'make install'
+                            }
+                        }
+                        stage('Python:3.6.5 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
                             }
                         }
                         stage('Python:3.6.5 Lint') {
@@ -453,6 +503,11 @@ pipeline {
                                 sh 'make install'
                             }
                         }
+                        stage('Python:3.6.6 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
+                            }
+                        }
                         stage('Python:3.6.6 Lint') {
                             steps {
                                 sh 'make lint'
@@ -492,6 +547,11 @@ pipeline {
                         stage('Python:3.6.7 Install') {
                             steps {
                                 sh 'make install'
+                            }
+                        }
+                        stage('Python:3.6.7 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
                             }
                         }
                         stage('Python:3.6.7 Lint') {
@@ -535,6 +595,11 @@ pipeline {
                                 sh 'make install'
                             }
                         }
+                        stage('Python:3.7.0 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
+                            }
+                        }
                         stage('Python:3.7.0 Lint') {
                             steps {
                                 sh 'make lint'
@@ -574,6 +639,11 @@ pipeline {
                         stage('Python:3.7.1 Install') {
                             steps {
                                 sh 'make install'
+                            }
+                        }
+                        stage('Python:3.7.1 Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
                             }
                         }
                         stage('Python:3.7.1 Lint') {

--- a/tools/gen_Jenkinsfile.py
+++ b/tools/gen_Jenkinsfile.py
@@ -78,9 +78,14 @@ STAGE = """
                                 sh 'make install'
                             }
                         }
-                        stage('Python:%(version)s Test') {
+                        stage('Python:%(version)s Lint') {
                             steps {
-                                sh 'make test'
+                                sh 'make lint'
+                            }
+                        }
+                        stage('Python:%(version)s Tests') {
+                            steps {
+                                sh 'make test-only'
                             }
                         }
                         stage('Python:%(version)s Cleanup') {

--- a/tools/gen_Jenkinsfile.py
+++ b/tools/gen_Jenkinsfile.py
@@ -73,11 +73,6 @@ STAGE = """
                                 sh 'make clean'
                             }
                         }
-                        stage('Python:%(version)s Install') {
-                            steps {
-                                sh 'make install'
-                            }
-                        }
                         stage('Python:%(version)s Test-Env') {
                             steps {
                                 sh 'make venv-dev'
@@ -91,6 +86,11 @@ STAGE = """
                         stage('Python:%(version)s Tests') {
                             steps {
                                 sh 'make test-only'
+                            }
+                        }
+                        stage('Python:%(version)s Install') {
+                            steps {
+                                sh 'make install'
                             }
                         }
                         stage('Python:%(version)s Cleanup') {

--- a/tools/gen_Jenkinsfile.py
+++ b/tools/gen_Jenkinsfile.py
@@ -78,6 +78,11 @@ STAGE = """
                                 sh 'make install'
                             }
                         }
+                        stage('Python:%(version)s Test-Env') {
+                            steps {
+                                sh 'make venv-dev'
+                            }
+                        }
                         stage('Python:%(version)s Lint') {
                             steps {
                                 sh 'make lint'


### PR DESCRIPTION
I split the test stage into three:
- create the venv and install the dev requirements
- run pylint
- run pytest

In case of a failure one can see at a single glance whether it occurred during the installation of deps, during the lint or due to a failed test-case.

In addition I moved the `install` stage to the very end, just before the clean up. Like that we skip downloading of the git-dependencies twice. Before they were downloaded and installed here:
- make install: via the dependency-link from the setup
- make venv-dev: again for the develop/editable installation


---

This is the Blue Ocean overview of a build:


Before:
![image](https://user-images.githubusercontent.com/17931887/51343001-9abc6d00-1a95-11e9-948b-db3a05c7aebc.png)

After:

![image](https://user-images.githubusercontent.com/17931887/51342964-82e4e900-1a95-11e9-92a1-7dbf2b6b1631.png)
