### PR TITLE
[hangups_conversation] retry sending

### DIFF
--- a/hangupsbot/hangups_conversation.py
+++ b/hangupsbot/hangups_conversation.py
@@ -223,18 +223,21 @@ class HangupsConversation(hangups.conversation.Conversation, BotMixin):
 
         request = hangouts_pb2.SendChatMessageRequest(**kwargs)
 
-        try:
-            # send the message
-            await self._client.send_chat_message(request)
-        except hangups.NetworkError as err:
-            logger.info(
-                'send_message failed %s: id=%r segments=%r image=%r context=%r',
-                id(err), self.id_, serialised_segments, image_id, context
-            )
-            logger.error(
-                'send_message failed %s: %r',
-                id(err), err
-            )
+        for retry in range(5):
+            try:
+                await self._client.send_chat_message(request)
+            except hangups.NetworkError as err:
+                logger.info(
+                    'send_message failed %s: '
+                    'id=%r segments=%r image=%r context=%r',
+                    id(err), self.id_, serialised_segments, image_id, context
+                )
+                logger.error(
+                    'send_message failed %s: %r',
+                    id(err), err
+                )
+            else:
+                break
 
 
 class HangupsConversationList(hangups.conversation.ConversationList, BotMixin):

--- a/hangupsbot/hangups_conversation.py
+++ b/hangupsbot/hangups_conversation.py
@@ -229,8 +229,9 @@ class HangupsConversation(hangups.conversation.Conversation, BotMixin):
             except hangups.NetworkError as err:
                 logger.info(
                     'send_message failed %s: '
-                    'id=%r segments=%r image=%r context=%r',
-                    id(err), self.id_, serialised_segments, image_id, context
+                    'retry=%d id=%r segments=%r image=%r context=%r',
+                    id(err), retry, self.id_, serialised_segments, image_id,
+                    context
                 )
                 logger.error(
                     'send_message failed %s: %r',

--- a/hangupsbot/hangups_conversation.py
+++ b/hangupsbot/hangups_conversation.py
@@ -235,6 +235,13 @@ class HangupsConversation(hangups.conversation.Conversation, BotMixin):
                     id(err), retry, self.id_, serialised_segments, image_id,
                     context
                 )
+
+                if 'Former member' in str(err):
+                    logger.warning(
+                        'send_message failed %s: %r',
+                        id(err), err
+                    )
+                    break
                 logger.error(
                     'send_message failed %s: %r',
                     id(err), err

--- a/hangupsbot/hangups_conversation.py
+++ b/hangupsbot/hangups_conversation.py
@@ -1,5 +1,7 @@
 """enhanced hangups conversation that supports a fallback to cached data"""
+import asyncio
 import logging
+import random
 import time
 
 import hangups
@@ -239,6 +241,8 @@ class HangupsConversation(hangups.conversation.Conversation, BotMixin):
                 )
             else:
                 break
+
+            await asyncio.sleep(random.randint(1, 5))
 
 
 class HangupsConversationList(hangups.conversation.ConversationList, BotMixin):

--- a/hangupsbot/hangups_conversation.py
+++ b/hangupsbot/hangups_conversation.py
@@ -242,10 +242,17 @@ class HangupsConversation(hangups.conversation.Conversation, BotMixin):
                         id(err), err
                     )
                     break
-                logger.error(
-                    'send_message failed %s: %r',
-                    id(err), err
-                )
+
+                if retry == 4:
+                    logger.error(
+                        'send_message failed %s: %r',
+                        id(err), err
+                    )
+                else:
+                    logger.info(
+                        'send_message failed %s: %r',
+                        id(err), err
+                    )
             else:
                 break
 


### PR DESCRIPTION
This PR fixes #97 in adding 5 retries for the message sending.

---

ops:

The message template for sending errors changed slightly:
- old:
  `send_message failed %s: id=%r segments=%r image=%r context=%r`
- new:
  `send_message failed %s: retry=%d id=%r segments=%r image=%r context=%r`