### PR TITLE
upgrade hangups to 0.4.6.7

### DIFF
--- a/hangupsbot/requirements.in
+++ b/hangupsbot/requirements.in
@@ -1,2 +1,2 @@
--e git+https://github.com/das7pad/hangups@v0.4.6.6#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.7#egg=hangups
 appdirs

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-dev-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.6#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.7#egg=hangups
 -e git+https://github.com/das7pad/raven-python.git@v6.10.2#egg=raven
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.5.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.6#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.7#egg=hangups
 -e git+https://github.com/das7pad/raven-python.git@v6.10.2#egg=raven
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.5.4


### PR DESCRIPTION
This PR bumps hangups to `0.4.6.7`.

`0.4.6.7` fixes a deprecation warning from `aiophttp`:
https://travis-ci.org/das7pad/hangoutsbot/jobs/481612446#L578
```
/some-venv/src/hangups/hangups/http_utils.py:35: DeprecationWarning: conn_timeout is deprecated, use timeout argument instead
    conn_timeout=CONNECT_TIMEOUT)
```

See the [release info](https://github.com/das7pad/hangups/releases/tag/v0.4.6.7) for additional changes and linked upstream issues.