### PR TITLE
[setup] hotfix for pip>=19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 # workaround py3.7 end
 
 before_install:
-    - $VIRTUAL_ENV/bin/pip install --upgrade 'pip<19'
+    - $VIRTUAL_ENV/bin/pip install --upgrade pip
 
 install:
     - make venv-dev venv=$VIRTUAL_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ EXPOSE $PORTS
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
 &&  mkdir /app \
+&&  pip install --no-cache-dir --upgrade 'pip>=18.1' \
 &&  true
 
 COPY requirements/requirements.txt /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN sed \
         --in-place=.org \
         /app/requirements.txt \
 &&  pip3 install \
-        --process-dependency-links \
         --no-cache-dir \
         --requirement /app/requirements.txt \
 &&  mv /app/requirements.txt.org /app/requirements.txt \
@@ -34,7 +33,6 @@ RUN sed \
 
 COPY . /app
 RUN pip3 install \
-        --process-dependency-links \
         --no-cache-dir \
         /app \
 &&  rm -rf /app \

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ install-requirements: venv-create
 .PHONY: install
 install: venv-create
 	rm -rf `find hangupsbot -name __pycache__`
-	$(pip) install . --process-dependency-links --upgrade
+	$(pip) install . --upgrade
 
 # update or reinstall all packages
 .PHONY: update-requirements

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ localization:
 venv-create: $(pip)
 $(pip):
 	${python} -m venv $(venv)
+	$(pip) install --upgrade pip
 
 # house keeping: update the requirements.in file
 requirements/requirements.in: $(shell find hangupsbot -type d)


### PR DESCRIPTION
The `pip install` option `--process-dependency-links` has been deprecated a few years ago without an actual replacement. The upstream-issue is here https://github.com/pypa/pip/issues/4187.

A replacement has landed in `pip==18.1` (2018-10) with the implementation of `PEP508` - a spec for URL dependencies.

`--process-dependency-links` has been removed with the release of `pip==19` (2019-01).

This PR implements parsing of the requirements file for the new URL dependency scheme.

Note: additional parsing is still required due to the usage of editable dependencies from git-repositories.
