### PR TITLE
[jenkins] skip the download of ffmpeg

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,8 @@ pipeline {
         GIT_COMMITTER_NAME  = 'Joe Doe'
         GIT_COMMITTER_EMAIL = 'joe.doe@example.com'
         HOME                = '/tmp/'
+        IMAGEIO_FFMPEG_EXE  = '/bin/true'
+        FFMPEG_BINARY       = '/bin/true'
     }
     options {
         timestamps()

--- a/tools/gen_Jenkinsfile.py
+++ b/tools/gen_Jenkinsfile.py
@@ -38,6 +38,8 @@ pipeline {
         GIT_COMMITTER_NAME  = 'Joe Doe'
         GIT_COMMITTER_EMAIL = 'joe.doe@example.com'
         HOME                = '/tmp/'
+        IMAGEIO_FFMPEG_EXE  = '/bin/true'
+        FFMPEG_BINARY       = '/bin/true'
     }
     options {
         timestamps()


### PR DESCRIPTION
We do not run any video-convert test, so there is no need to download `ffmpeg` for the tests.

The patch is actually a bit _hacky_, but it works as intended.

- `IMAGEIO_FFMPEG_EXE` is used to trick `imageio.plugins.ffmpeg.get_exe()`.
- `FFMPEG_BINARY` is used to trick `moviepy.editor` 