### PR TITLE
upgrade hangups to 0.4.6.8

### DIFF
--- a/hangupsbot/requirements.in
+++ b/hangupsbot/requirements.in
@@ -1,2 +1,2 @@
--e git+https://github.com/das7pad/hangups@v0.4.6.7#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.8#egg=hangups
 appdirs

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-dev-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.7#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.8#egg=hangups
 -e git+https://github.com/das7pad/raven-python.git@v6.10.2#egg=raven
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.5.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.6.7#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.6.8#egg=hangups
 -e git+https://github.com/das7pad/raven-python.git@v6.10.2#egg=raven
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.5.4


### PR DESCRIPTION
This PR bumps hangups to `0.4.6.8`.

`0.4.6.8` fixes invalid ip-address matches from the auto-link regex.

See the [release info](https://github.com/das7pad/hangups/releases/tag/v0.4.6.8) for additional changes and linked upstream issues.