### PR TITLE
[slackrtm] rate limit api requests

### DIFF
--- a/hangupsbot/plugins/slackrtm/constants.py
+++ b/hangupsbot/plugins/slackrtm/constants.py
@@ -89,3 +89,21 @@ MESSAGE_TYPES_TO_SKIP = (
 )
 MESSAGE_SUBTYPES_MEMBERSHIP_JOIN = ('channel_join', 'group_join')
 MESSAGE_SUBTYPES_MEMBERSHIP_LEAVE = ('channel_leave', 'group_leave')
+
+RATE_LIMITS = {
+    method: (60, 3, 1.25, 0.6)[tier-1]
+    for method, tier in {
+        'channels.history': 3,
+        'channels.kick': 3,
+        'channels.list': 2,
+        'groups.history': 3,
+        'groups.kick': 2,
+        'groups.list': 3,
+        'im.history': 4,
+        'im.list': 2,
+        'im.open': 4,
+        'rtm.connect': 1,
+        'team.info': 3,
+        'users.list': 2,
+    }.items()
+}

--- a/hangupsbot/plugins/slackrtm/core.py
+++ b/hangupsbot/plugins/slackrtm/core.py
@@ -434,6 +434,13 @@ class SlackRTM(BotMixin):
                 delay += int(resp.headers['Retry-After'])
             except ValueError:
                 delay += 30
+
+            if method in RATE_LIMITS:
+                # propagate the rate limit immediately
+                last_call = self._api_call_history[method]
+                now = time.time()
+                self._api_call_history[method] = max(last_call, now) + delay
+
             return await self.api_call(method, delay=delay, **kwargs)
         except (aiohttp.ClientError, ValueError, RuntimeError) as err:
             self.logger.info(

--- a/hangupsbot/plugins/slackrtm/core.py
+++ b/hangupsbot/plugins/slackrtm/core.py
@@ -8,7 +8,6 @@ import aiohttp
 
 from hangupsbot import plugins
 from hangupsbot.base_models import BotMixin
-from hangupsbot.sync.sending_queue import AsyncQueueCache
 from hangupsbot.sync.user import SyncUser
 from hangupsbot.sync.utils import get_sync_config_entry
 from .commands_slack import slack_command_handler
@@ -38,6 +37,7 @@ from .message import SlackMessage
 from .parsers import (
     SLACK_STYLE,
 )
+from .sending_queue import SlackMessageQueueCache
 from .storage import (
     migrate_on_domain_change,
 )
@@ -361,7 +361,7 @@ class SlackRTM(BotMixin):
 
         migrate_on_domain_change(self, old_domain)
 
-        self._cache_sending_queue = AsyncQueueCache(
+        self._cache_sending_queue = SlackMessageQueueCache(
             self.identifier, _send_message, bot=self.bot)
 
         await _register_handler()

--- a/hangupsbot/plugins/slackrtm/core.py
+++ b/hangupsbot/plugins/slackrtm/core.py
@@ -431,9 +431,9 @@ class SlackRTM(BotMixin):
         except SlackRateLimited:
             self.logger.warning('api_call %s: rate limit hit', tracker)
             try:
-                delay += int(resp.headers['Retry-After'])
+                delay = int(resp.headers['Retry-After'])
             except ValueError:
-                delay += 30
+                delay = 30
 
             if method in RATE_LIMITS:
                 # propagate the rate limit immediately

--- a/hangupsbot/plugins/slackrtm/sending_queue.py
+++ b/hangupsbot/plugins/slackrtm/sending_queue.py
@@ -1,0 +1,35 @@
+"""Apply the rate limit per channel to the sending queue"""
+
+import asyncio
+
+from hangupsbot.sync.sending_queue import (
+    AsyncQueue,
+    QueueCache,
+)
+
+
+class SlackMessageQueue(AsyncQueue):
+    __slots__ = (
+        '_next_message',
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._next_message = 0
+
+    async def _send(self, args, kwargs):
+        """This method is called sequentially"""
+        now = self._loop.time()
+
+        if self._next_message > now:
+            await asyncio.sleep(self._next_message - now)
+
+        try:
+            await super()._send(args, kwargs)
+        finally:
+            self._next_message = self._loop.time() + 1
+
+
+class SlackMessageQueueCache(QueueCache):
+    __slots__ = ()
+    _queue = SlackMessageQueue


### PR DESCRIPTION
- Fix: the `Retry-After` value is in the header, not part of the body https://github.com/das7pad/hangoutsbot/commit/af578470cbf117103b81756ef299a93254c6b19f
  See Slack API docs: https://api.slack.com/docs/rate-limits#headers
- Feature: Implement the rate limits as offsets between requests https://github.com/das7pad/hangoutsbot/commit/7a5ada5ebbe1383e0b2d203360b7e4fb3d996287
  The actual rate limits are divided into `Tier`s which allow a certain number of requests per minute.
  Tracking each request to determine the number of requests in the last minute is not in the scope of this package.
  See Slack API docs:
    - Tiers: https://api.slack.com/docs/rate-limits#tiers
    - `im.open` as an example for `Tier 4`: https://api.slack.com/methods/im.open#facts
- Feature: Limit the message sending per channel to 1 message per second. https://github.com/das7pad/hangoutsbot/commit/213826b42101cf429d000b0b8fa018ed3fc799e2
  See Slack API docs: https://api.slack.com/docs/rate-limits#posting_messages