### PR TITLE
[slackrtm] only reconnect from closed websockets

### DIFF
--- a/hangupsbot/plugins/slackrtm/core.py
+++ b/hangupsbot/plugins/slackrtm/core.py
@@ -225,7 +225,9 @@ class SlackRTM(BotMixin):
 
                 while True:
                     await self._process_websocket(login_data['url'])
-                    self.logger.info('websocket closed gracefully, restarting')
+                    self.logger.info(
+                        'websocket closed gracefully, reconnecting'
+                    )
                     hard_reset = 1
                     login_data = await _login()
 

--- a/hangupsbot/plugins/slackrtm/core.py
+++ b/hangupsbot/plugins/slackrtm/core.py
@@ -717,8 +717,14 @@ class SlackRTM(BotMixin):
                     try:
                         reply = json.loads(msg.data)
                         if 'type' not in reply:
-                            raise ValueError('reply has no `type` entry: %s'
-                                             % repr(reply))
+                            self.logger.info(
+                                'bad reply %s: %r',
+                                id(reply), reply
+                            )
+                            raise ValueError(
+                                'reply has no `type` entry: %s'
+                                % id(reply)
+                            )
                     except (ValueError, TypeError) as err:
                         # covers invalid json-replies, replies without a `type`
                         self.logger.error('bad websocket read: %r', err)

--- a/hangupsbot/plugins/slackrtm/core.py
+++ b/hangupsbot/plugins/slackrtm/core.py
@@ -226,6 +226,7 @@ class SlackRTM(BotMixin):
                 while True:
                     await self._process_websocket(login_data['url'])
                     self.logger.info('websocket closed gracefully, restarting')
+                    hard_reset = 1
                     login_data = await _login()
 
             except asyncio.CancelledError:

--- a/hangupsbot/plugins/slackrtm/core.py
+++ b/hangupsbot/plugins/slackrtm/core.py
@@ -223,7 +223,11 @@ class SlackRTM(BotMixin):
                 await _set_self_user_and_ids(login_data)
                 await self.rebuild_base()
 
-                await self._process_websocket(login_data['url'])
+                while True:
+                    await self._process_websocket(login_data['url'])
+                    self.logger.info('websocket closed gracefully, restarting')
+                    login_data = await _login()
+
             except asyncio.CancelledError:
                 return
             except IncompleteLoginError as err:
@@ -247,9 +251,6 @@ class SlackRTM(BotMixin):
                 return
             except Exception:  # pylint: disable=broad-except
                 self.logger.exception('core error')
-            else:
-                self.logger.info('websocket closed gracefully, restarting')
-                hard_reset = 0
             finally:
                 self.logger.debug('unloading')
                 self.bot.config.on_reload.remove_observer(self.rebuild_base)

--- a/hangupsbot/plugins/slackrtm/core.py
+++ b/hangupsbot/plugins/slackrtm/core.py
@@ -1,6 +1,7 @@
 """core to handle message syncing and handle base requests from commands"""
 
 import asyncio
+import json
 import logging
 import time
 
@@ -711,29 +712,27 @@ class SlackRTM(BotMixin):
                 self.logger.info('started new SlackRTM connection')
 
                 soft_reset = 0
-                while soft_reset < 5:
+                async for msg in websocket:
                     try:
-                        reply = await websocket.receive_json()
-                        if not reply:
-                            # gracefully stopped
-                            return
+                        reply = json.loads(msg.data)
                         if 'type' not in reply:
                             raise ValueError('reply has no `type` entry: %s'
                                              % repr(reply))
                     except (ValueError, TypeError) as err:
-                        if websocket.closed:
-                            self.logger.info('websocket connection closed')
-                            break
                         # covers invalid json-replies, replies without a `type`
                         self.logger.error('bad websocket read: %r', err)
+                        if soft_reset >= 5:
+                            break
                         soft_reset += 1
                         await asyncio.sleep(2 ** soft_reset)
-                        continue
 
                     await self._handle_slack_message(reply)
 
                     # valid response handled, leave fail-state
                     soft_reset = 0
+                else:
+                    # gracefully stopped
+                    return
 
         except aiohttp.ClientError as err:
             self.logger.error('websocket connection failed: %r', err)


### PR DESCRIPTION
This PR reduces the delay between reconnects.

The current behavior, after a web socket got closed, is a full rebuild of the instance. This is not needed. We can request a new web socket and continue to use the cached data, message queues and keep the propagated handlers in place. https://github.com/das7pad/hangoutsbot/commit/65f49ad3bdb8bc1650191ba34e5efa38daf9e6e2

The web socket processing received a cleanup by using the `async for` capability of a `aiohttp.ClientWebSocketResponse`. It stops the iteration when receiving a closing, close or closed message, which we then interpret as a graceful stop. https://github.com/das7pad/hangoutsbot/commit/18534832e95acb411237e4e0d7baa32184b4a8bb
