### PR TITLE
[core] hide the cookies in a private variable

### DIFF
--- a/hangupsbot/core.py
+++ b/hangupsbot/core.py
@@ -65,6 +65,7 @@ class HangupsBot:
     def __init__(self, cookies_path, config_path, memory_path, max_retries):
         self._client = None
         self._cookies_path = cookies_path
+        self.__cookies = {}
         self._max_retries = max_retries
         self.__retry = 0
         self.__retry_resetter = None
@@ -255,7 +256,7 @@ class HangupsBot:
                 # restore the functionality to stop the bot on KeyboardInterrupt
                 self.stop = self._schedule_stop
 
-        cookies = _login()
+        self.__cookies = _login()
 
         # Start asyncio event loop
         loop = asyncio.get_event_loop()
@@ -280,7 +281,10 @@ class HangupsBot:
         while self.__retry < self._max_retries:
             self.__retry += 1
             # (re)create the Hangups client
-            self._client = hangups.Client(cookies, max_retries_longpolling)
+            self._client = hangups.Client(
+                cookies=self.__cookies,
+                max_retries=max_retries_longpolling
+            )
             self._client.on_connect.add_observer(self._on_connect)
             self._client.on_disconnect.add_observer(
                 lambda: logger.info("Event polling stopped"))


### PR DESCRIPTION
This is only relevant for users with error reporting/debugging tools enabled - such as sentry.

Additional configuration changes are required that then lead to an exposure of the `cookies` in the error reporting. In case of sentry, the user must explicitly enable extended debugging via the config value `config['sentry']['options']['capture_locals'] = True`. A warning is already present in the docs [1].

A low level error in `hangups.channel.Channel.listen` or any error in combination with another explicit config option for sentry `auto_log_stacks`, could then include the `hangupsbot.core.HangupsBot.run` stack frame.
The mentioned low level errors are very rare and are related to buggy roll outs on server side [2] or unstable network connectivity [3].

---
[1] https://github.com/das7pad/hangoutsbot/blob/375280f508bdbac0120becd10140fed049644c9d/hangupsbot/plugins/sentry/__init__.py#L17-L18
[2] I have seen `404` error responses for the channel once or twice in the past few years.
[3] Network connectivity is required to run the login requests - otherwise there are no cookies available to expose - and must drop afterwards for an extended time span as hangups will retry network requests by default 5 times.