### PR TITLE
[misc] fix a package name change in the requirements files

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -53,8 +53,8 @@ pylint==2.2.2
 pyslack==0.4.0
 pytest-asyncio==0.10.0
 pytest==4.2.0
+python-dateutil==2.8.0
 python-magic==0.4.15
-python_dateutil==2.8.0
 raven-aiohttp==0.7.0
 reparser==1.4.3
 requests-oauthlib==1.2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -42,8 +42,8 @@ pushbullet.py==0.11.0
 pyasn1-modules==0.2.4
 pyasn1==0.4.5
 pyslack==0.4.0
+python-dateutil==2.8.0
 python-magic==0.4.15
-python_dateutil==2.8.0
 raven-aiohttp==0.7.0
 reparser==1.4.3
 requests-oauthlib==1.2.0


### PR DESCRIPTION
As per the discussion in #129 the name change for `python-dateutil` by dependabot is a bug.

Ref: 0f47a857f670c162775d00e6ef4317f4a114c702