### PR TITLE
[slackrtm] improve ws error handling

### DIFF
--- a/hangupsbot/plugins/slackrtm/core.py
+++ b/hangupsbot/plugins/slackrtm/core.py
@@ -757,6 +757,17 @@ class SlackRTM(BotMixin):
                             break
                         soft_reset += 1
                         await asyncio.sleep(2 ** soft_reset)
+                        continue
+
+                    if 'error' in reply:
+                        error = reply['error']
+                        if isinstance(error, dict) and 'msg' in error:
+                            msg = error['msg']
+                        else:
+                            msg = repr(error)
+
+                        self.logger.error('websocket error: %s', msg)
+                        break
 
                     await self._handle_slack_message(reply)
 

--- a/hangupsbot/plugins/slackrtm/exceptions.py
+++ b/hangupsbot/plugins/slackrtm/exceptions.py
@@ -21,10 +21,6 @@ class IncompleteLoginError(Exception):
     """did not receive a full rtm.connect response on login"""
 
 
-class WebsocketFailed(Exception):
-    """can not establish a connection or reading failed permanent"""
-
-
 class SlackAPIError(Exception):
     """invalid request or missing permissions"""
 


### PR DESCRIPTION
The web socket may receive messages, like this one:

```json
{
  "error": {
    "code": 1, 
    "msg": "Socket URL has expired", 
    "source": "123-abc-xyz"
  }, 
  "type": "error"
}
```

These error messages should trigger a reconnect. https://github.com/das7pad/hangoutsbot/commit/4dab88478f8df366d6e09df3c43bd4903a82af22

The reconnect is an actual reconnect now, previously the instance was rebuild from scratch. https://github.com/das7pad/hangoutsbot/commit/8584e480c59abc7fbcba325150a1480b6c668345

Ref: https://sentry.das7pad.de/sentry/hangoutsbot/issues/109/
