### PR TITLE
upgrade hangups to 0.4.9.1

### DIFF
--- a/hangupsbot/requirements.in
+++ b/hangupsbot/requirements.in
@@ -1,2 +1,2 @@
--e git+https://github.com/das7pad/hangups@v0.4.7.1#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.9.1#egg=hangups
 appdirs

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-dev-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.7.1#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.9.1#egg=hangups
 -e git+https://github.com/das7pad/raven-python.git@v6.10.2#egg=raven
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.5.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make gen-requirements
 #
--e git+https://github.com/das7pad/hangups@v0.4.7.1#egg=hangups
+-e git+https://github.com/das7pad/hangups@v0.4.9.1#egg=hangups
 -e git+https://github.com/das7pad/raven-python.git@v6.10.2#egg=raven
 -e git+https://github.com/das7pad/telepot.git@v12.6.1#egg=telepot
 aiohttp==3.5.4


### PR DESCRIPTION
This PR bumps hangups to `0.4.9.1`.

`0.4.9.1` fixes a duplicate event per conversation for plugins which request events directly from hangups.

See the [release info](https://github.com/das7pad/hangups/releases/tag/v0.4.9.1) for additional changes and linked upstream issues.