### PR TITLE
[permamem] keep valid names and titles

### DIFF
--- a/hangupsbot/permamem.py
+++ b/hangupsbot/permamem.py
@@ -316,6 +316,14 @@ class ConversationMemory(BotMixin):
         cached = (self.bot.memory.get_by_path(["convmem", conv.id_])
                   if self.bot.memory.exists(["convmem", conv.id_]) else {})
 
+        if conv_title.lower() == "unknown" and "title" in cached:
+            conv_title = cached['title']
+            logger.info(
+                "conv title recovered for %s (%s)",
+                conv.id_,
+                conv_title,
+            )
+
         memory = {
             "title": conv_title,
             "source": source,

--- a/hangupsbot/permamem.py
+++ b/hangupsbot/permamem.py
@@ -49,10 +49,15 @@ def load_missing_entries(bot):
                 '_hangups' not in user_data)):
             continue
         user_id = hangups.user.UserID(chat_id=chat_id, gaia_id=chat_id)
-        user = hangups.user.User(user_id, user_data["_hangups"]["full_name"],
-                                 user_data["_hangups"]["first_name"],
-                                 user_data["_hangups"]["photo_url"],
-                                 user_data["_hangups"]["emails"], False)
+        cache = user_data["_hangups"]
+        user = hangups.user.User(
+            user_id,
+            cache["full_name"],
+            cache["first_name"],
+            cache["photo_url"],
+            cache["emails"],
+            cache["is_self"],
+        )
         loaded_users[user_id] = user
 
     for conv_id in bot.conversations:

--- a/hangupsbot/permamem.py
+++ b/hangupsbot/permamem.py
@@ -49,8 +49,6 @@ def load_missing_entries(bot):
                 '_hangups' not in user_data)):
             continue
         user_id = hangups.user.UserID(chat_id=chat_id, gaia_id=chat_id)
-        if user_id in loaded_users:
-            continue
         user = hangups.user.User(user_id, user_data["_hangups"]["full_name"],
                                  user_data["_hangups"]["first_name"],
                                  user_data["_hangups"]["photo_url"],


### PR DESCRIPTION
Many users and conversations show up as `unknown` in hangouts. We can use our memory.json cache to bring back the missing values and ensure that they do not overwrite our known non-default values.

Note: additional detection for the default user name is done upstream in hangups, see PR #183 .