### PR TITLE
[permamem] improve performance

### DIFF
--- a/hangupsbot/commands/permamem.py
+++ b/hangupsbot/commands/permamem.py
@@ -44,9 +44,6 @@ def dumpunknownusers(bot, *dummys):
 
     if bot.memory.exists(["user_data"]):
         for chat_id in bot.memory["user_data"]:
-            if "_hangups" not in bot.memory["user_data"][chat_id]:
-                continue
-
             _hangups = bot.memory["user_data"][chat_id]["_hangups"]
             if not _hangups["is_definitive"]:
                 continue
@@ -66,9 +63,6 @@ def resetunknownusers(bot, *dummys):
 
     if bot.memory.exists(["user_data"]):
         for chat_id in bot.memory["user_data"]:
-            if "_hangups" not in bot.memory["user_data"][chat_id]:
-                continue
-
             _hangups = bot.memory["user_data"][chat_id]["_hangups"]
             if not _hangups["is_definitive"]:
                 continue
@@ -113,9 +107,6 @@ def makeallusersindefinite(bot, *dummys):
 
     if bot.memory.exists(["user_data"]):
         for chat_id in bot.memory["user_data"]:
-            if "_hangups" not in bot.memory["user_data"][chat_id]:
-                continue
-
             bot.memory.set_by_path(
                 ["user_data", chat_id, "_hangups", "is_definitive"], False)
 

--- a/hangupsbot/permamem.py
+++ b/hangupsbot/permamem.py
@@ -363,6 +363,10 @@ class ConversationMemory(BotMixin):
             if not user.is_self:
                 memory["participants"].append(user.id_.chat_id)
 
+            if source == "init":
+                # hot path: skip the redundant user data diff calc during init
+                continue
+
             if user.name_type == hangups.user.NameType.DEFAULT:
                 _users_to_fetch.append(user.id_.chat_id)
 

--- a/hangupsbot/permamem.py
+++ b/hangupsbot/permamem.py
@@ -368,7 +368,7 @@ class ConversationMemory(BotMixin):
 
             users_changed = self.store_user_memory(user) or users_changed
 
-        if _users_to_fetch:
+        if _users_to_fetch and source != "init":
             logger.info("unknown users returned from %s (%s): %s",
                         conv_title, conv.id_, _users_to_fetch)
             await self.get_users_from_query(_users_to_fetch)

--- a/hangupsbot/permamem.py
+++ b/hangupsbot/permamem.py
@@ -319,7 +319,10 @@ class ConversationMemory(BotMixin):
         if changed:
             logger.info(message, key, user.full_name, user.id_.chat_id)
             user_dict["updated"] = datetime.now().strftime("%Y%m%d%H%M%S")
-            self.bot.user_memory_set(user.id_.chat_id, "_hangups", user_dict)
+            self.bot.memory.set_by_path(
+                ['user_data', user.id_.chat_id, "_hangups"],
+                user_dict
+            )
         return changed
 
     async def update(self, conv, source="unknown", automatic_save=True):

--- a/hangupsbot/permamem.py
+++ b/hangupsbot/permamem.py
@@ -200,20 +200,14 @@ class ConversationMemory(BotMixin):
             _users_found.update(conv["participants"])
 
         for chat_id in _users_found:
-            userid = hangups.user.UserID(chat_id=chat_id,
-                                         gaia_id=chat_id)
-            try:
-                self.bot._user_list._user_dict[userid]
-            except KeyError:
-                cached = self.bot.user_memory_get(chat_id, "_hangups")
-                if cached is not None:
-                    if cached["is_definitive"]:
-                        continue
-                    _users_incomplete[chat_id] = cached["full_name"]
-                else:
-                    _users_unknown.append(chat_id)
-
-                _users_to_fetch.append(chat_id)
+            cached = self.bot.user_memory_get(chat_id, "_hangups")
+            if cached is not None:
+                if cached["is_definitive"]:
+                    continue
+                _users_incomplete[chat_id] = cached["full_name"]
+            else:
+                _users_unknown.append(chat_id)
+            _users_to_fetch.append(chat_id)
 
         if _users_incomplete:
             logger.info("incomplete users: %s", _users_incomplete)

--- a/hangupsbot/permamem.py
+++ b/hangupsbot/permamem.py
@@ -159,7 +159,6 @@ class ConversationMemory(BotMixin):
         convs = self.bot.memory.get_by_path(['convmem'])
         logger.debug("loading %s conversations from memory", len(convs))
 
-        _users_added = {}
         _users_incomplete = {}
         _users_unknown = []
 
@@ -174,7 +173,7 @@ class ConversationMemory(BotMixin):
             userid = hangups.user.UserID(chat_id=chat_id,
                                          gaia_id=chat_id)
             try:
-                user = self.bot._user_list._user_dict[userid]
+                self.bot._user_list._user_dict[userid]
             except KeyError:
                 cached = self.bot.user_memory_get(chat_id, "_hangups")
                 if cached is not None:
@@ -185,13 +184,6 @@ class ConversationMemory(BotMixin):
                     _users_unknown.append(chat_id)
 
                 _users_to_fetch.append(chat_id)
-            else:
-                results = self.store_user_memory(user)
-                if results:
-                    _users_added[chat_id] = user.full_name
-
-        if _users_added:
-            logger.info("added users: %s", _users_added)
 
         if _users_incomplete:
             logger.info("incomplete users: %s", _users_incomplete)

--- a/hangupsbot/permamem.py
+++ b/hangupsbot/permamem.py
@@ -189,11 +189,10 @@ class ConversationMemory(BotMixin):
         convs = self.bot.memory.get_by_path(['convmem'])
         logger.debug("loading %s conversations from memory", len(convs))
 
-        _users_incomplete = {}
+        _users_incomplete = []
         _users_unknown = []
 
         _users_found = set()
-        _users_to_fetch = []
 
         for convid, conv in convs.items():
             self.catalog[convid] = conv
@@ -204,10 +203,9 @@ class ConversationMemory(BotMixin):
             if cached is not None:
                 if cached["is_definitive"]:
                     continue
-                _users_incomplete[chat_id] = cached["full_name"]
+                _users_incomplete.append(chat_id)
             else:
                 _users_unknown.append(chat_id)
-            _users_to_fetch.append(chat_id)
 
         if _users_incomplete:
             logger.info("incomplete users: %s", _users_incomplete)
@@ -215,6 +213,7 @@ class ConversationMemory(BotMixin):
         if _users_unknown:
             logger.warning("unknown users: %s", _users_unknown)
 
+        _users_to_fetch = _users_incomplete + _users_unknown
         if _users_to_fetch:
             await self.get_users_from_query(_users_to_fetch)
 


### PR DESCRIPTION
This PR improves the performance of the permamem init.

One instance with ~400 users, 150 chats from hangups and another 50 users and 200 conversations from cache had a performance boost of roughly x20: from 20 seconds down to one second.

The helper methods for user and conversation updates were not optimized for batch processing of users/conversation. I could eliminate many duplicate diff calculations and network calls.

As part of this PR I added a cleanup procedure into the `standardise_memory` method.
Invalid users are moved out of the `user_data` section in the memory.json. Every change is logged on level warning with explicit paths.
E.g.
```
2019-04-07 22:29:28,341 WARNING hangupsbot.permamem: Invalid user data found and moved: ['user_data', 'an_invalid_user_id'] -> ['_invalid_user_data', 'an_invalid_user_id']
```

The path `memory->user_data->CHAT_ID->_hangups->is_definitive` is available for all users in `memory->user_data`. Additional guard checks on `_hangups` in other parts of the code base were dropped.