### PR TITLE
[handlers] close: do not panic when the conv list is gone already

### DIFF
--- a/hangupsbot/handlers.py
+++ b/hangupsbot/handlers.py
@@ -517,10 +517,11 @@ class EventHandler(BotMixin):
         self.pluggables.clear()
 
         conv_list = self.bot._conv_list  # pylint:disable=protected-access
-        conv_list.on_event.remove_observer(self._handle_event)
-        conv_list.on_typing.remove_observer(self._handle_status_change)
-        conv_list.on_watermark_notification.remove_observer(
-            self._handle_status_change)
+        if conv_list is not None:
+            conv_list.on_event.remove_observer(self._handle_event)
+            conv_list.on_typing.remove_observer(self._handle_status_change)
+            conv_list.on_watermark_notification.remove_observer(
+                self._handle_status_change)
 
 
 class HandlerBridge(BotMixin):


### PR DESCRIPTION
``` 
ERROR asyncio: Task exception was never retrieved
future: <Task finished coro=<HangupsBot._unload() done, defined at /usr/local/lib/python3.6/site-packages/hangupsbot/core.py:317> exception=AttributeError("'NoneType' object has no attribute 'on_event'",)>
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/hangupsbot/core.py", line 338, in _unload
    await self._handlers.close()
  File "/usr/local/lib/python3.6/site-packages/hangupsbot/handlers.py", line 520, in close
    conv_list.on_event.remove_observer(self._handle_event)
AttributeError: 'NoneType' object has no attribute 'on_event'
```